### PR TITLE
0.0.46

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,5 @@ cython_debug/
 /scp-frogs
 scp_small.zip
 *.mp3
+/frogs_dataset
+/frogs_out

--- a/examples/inat_workflow.sh
+++ b/examples/inat_workflow.sh
@@ -6,13 +6,13 @@
 bioamla inat-audio ./frogs_dataset \
     --taxon-ids "24268, 65982, 23930, 24263, 65979, 66002, 66012, 60341, 64968, 64977, 24256" \
     --quality-grade research \
-    --obs-per-taxon 6
+    --obs-per-taxon 100
 
 # Step 2: Convert all audio files in the dataset to WAV format
 bioamla convert-audio ./frogs_dataset wav
 
 # Step 3: Fine-tune an audio spectrogram transformer (AST) model on the downloaded dataset
-bioamla ast-finetune --training-dir ./frogs_out --train-dataset ./frogs_dataset --num-train-epochs 2
+bioamla ast-finetune --training-dir ./frogs_out --train-dataset ./frogs_dataset --num-train-epochs 25
 
 # Step 4: Download a test dataset
 bioamla download https://www.bioamla.org/datasets/scp_small.zip .

--- a/src/bioamla/core/ast.py
+++ b/src/bioamla/core/ast.py
@@ -169,10 +169,11 @@ def load_pretrained_ast_model(model_path: str) -> AutoModelForAudioClassificatio
         The device_map="auto" parameter automatically distributes the model
         across available GPUs if present, otherwise uses CPU.
     """
-    import os
+    from pathlib import Path
 
-    # Check if model_path looks like a local path (contains path separators or starts with . or /)
-    is_local_path = os.path.sep in model_path or model_path.startswith(('.', '/'))
+    # Check if model_path is a local path by verifying it exists on the filesystem
+    # This correctly handles HuggingFace repo IDs like 'org/model' which contain '/'
+    is_local_path = Path(model_path).exists() or model_path.startswith(('./', '../'))
 
     if is_local_path:
         return AutoModelForAudioClassification.from_pretrained(model_path, device_map="auto", local_files_only=True)

--- a/src/bioamla/core/inat.py
+++ b/src/bioamla/core/inat.py
@@ -278,6 +278,23 @@ def download_inat_audio(
                 species_name = taxon.get("name", "unknown")
                 common_name = taxon.get("preferred_common_name", "")
                 taxon_id_val = taxon.get("id", "")
+                taxon_rank = taxon.get("rank", "")
+
+                # For subspecies/varieties, use the parent species name for grouping
+                # The rank field tells us if this is a subspecies, variety, etc.
+                if taxon_rank in ("subspecies", "variety", "form"):
+                    # Try to get the species-level name from ancestors or by truncating
+                    ancestors = taxon.get("ancestors", [])
+                    # Find the species-level ancestor
+                    for ancestor in reversed(ancestors):
+                        if ancestor.get("rank") == "species":
+                            species_name = ancestor.get("name", species_name)
+                            break
+                    else:
+                        # Fallback: take first two words (genus + species) from subspecies name
+                        name_parts = species_name.split()
+                        if len(name_parts) >= 2:
+                            species_name = " ".join(name_parts[:2])
 
                 observed_on = obs.get("observed_on", "")
                 location = obs.get("location", "")

--- a/src/bioamla/core/metadata.py
+++ b/src/bioamla/core/metadata.py
@@ -102,9 +102,19 @@ def write_metadata_csv(
         When merge_existing is True, rows are deduplicated by file_name.
         Required fields are ordered first, followed by optional fields.
     """
+    # Handle empty rows case
     if not rows:
-        logger.debug("No rows to write")
-        return 0
+        if merge_existing:
+            # When merging, no rows means nothing to add, keep existing
+            logger.debug("No rows to write")
+            return 0
+        else:
+            # When not merging, empty rows means clear the file
+            logger.debug("Writing empty metadata file (clearing existing)")
+            with open(filepath, "w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(f, fieldnames=REQUIRED_FIELDS)
+                writer.writeheader()
+            return 0
 
     # Derive fieldnames from rows if not provided
     if fieldnames is None:

--- a/tests/unit/test_ast.py
+++ b/tests/unit/test_ast.py
@@ -1,0 +1,96 @@
+"""
+Unit tests for bioamla.core.ast module.
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+class TestLoadPretrainedAstModel:
+    """Tests for load_pretrained_ast_model function."""
+
+    def test_local_path_exists_uses_local_files_only(self, temp_dir):
+        """Test that existing local paths use local_files_only=True."""
+        # Create a fake model directory
+        model_dir = temp_dir / "my_model"
+        model_dir.mkdir()
+
+        with patch("bioamla.core.ast.AutoModelForAudioClassification") as mock_model:
+            mock_model.from_pretrained.return_value = MagicMock()
+
+            from bioamla.core.ast import load_pretrained_ast_model
+            load_pretrained_ast_model(str(model_dir))
+
+            mock_model.from_pretrained.assert_called_once_with(
+                str(model_dir),
+                device_map="auto",
+                local_files_only=True
+            )
+
+    def test_relative_path_starting_with_dot_uses_local_files_only(self):
+        """Test that paths starting with ./ use local_files_only=True."""
+        with patch("bioamla.core.ast.AutoModelForAudioClassification") as mock_model:
+            mock_model.from_pretrained.return_value = MagicMock()
+
+            from bioamla.core.ast import load_pretrained_ast_model
+            load_pretrained_ast_model("./models/my_ast")
+
+            mock_model.from_pretrained.assert_called_once_with(
+                "./models/my_ast",
+                device_map="auto",
+                local_files_only=True
+            )
+
+    def test_relative_parent_path_uses_local_files_only(self):
+        """Test that paths starting with ../ use local_files_only=True."""
+        with patch("bioamla.core.ast.AutoModelForAudioClassification") as mock_model:
+            mock_model.from_pretrained.return_value = MagicMock()
+
+            from bioamla.core.ast import load_pretrained_ast_model
+            load_pretrained_ast_model("../models/my_ast")
+
+            mock_model.from_pretrained.assert_called_once_with(
+                "../models/my_ast",
+                device_map="auto",
+                local_files_only=True
+            )
+
+    def test_huggingface_repo_id_does_not_use_local_files_only(self):
+        """Test that HuggingFace repo IDs like 'org/model' don't use local_files_only."""
+        with patch("bioamla.core.ast.AutoModelForAudioClassification") as mock_model:
+            mock_model.from_pretrained.return_value = MagicMock()
+
+            from bioamla.core.ast import load_pretrained_ast_model
+            load_pretrained_ast_model("MIT/ast-finetuned-audioset-10-10-0.4593")
+
+            mock_model.from_pretrained.assert_called_once_with(
+                "MIT/ast-finetuned-audioset-10-10-0.4593",
+                device_map="auto"
+            )
+
+    def test_huggingface_repo_with_org_does_not_use_local_files_only(self):
+        """Test that org/model format is recognized as HuggingFace repo ID."""
+        with patch("bioamla.core.ast.AutoModelForAudioClassification") as mock_model:
+            mock_model.from_pretrained.return_value = MagicMock()
+
+            from bioamla.core.ast import load_pretrained_ast_model
+            load_pretrained_ast_model("facebook/wav2vec2-base")
+
+            mock_model.from_pretrained.assert_called_once_with(
+                "facebook/wav2vec2-base",
+                device_map="auto"
+            )
+
+    def test_simple_model_name_does_not_use_local_files_only(self):
+        """Test that simple model names without paths don't use local_files_only."""
+        with patch("bioamla.core.ast.AutoModelForAudioClassification") as mock_model:
+            mock_model.from_pretrained.return_value = MagicMock()
+
+            from bioamla.core.ast import load_pretrained_ast_model
+            load_pretrained_ast_model("bert-base-uncased")
+
+            mock_model.from_pretrained.assert_called_once_with(
+                "bert-base-uncased",
+                device_map="auto"
+            )

--- a/tests/unit/test_cli_download.py
+++ b/tests/unit/test_cli_download.py
@@ -1,0 +1,118 @@
+"""
+Unit tests for bioamla CLI download command.
+"""
+
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from click.testing import CliRunner
+
+from bioamla.cli import cli
+
+
+class TestDownloadCommand:
+    """Tests for the download CLI command."""
+
+    def test_download_extracts_filename_from_url(self, tmp_path, monkeypatch):
+        """Test that download extracts filename from URL and constructs full path."""
+        monkeypatch.chdir(tmp_path)
+
+        calls = []
+        def fake_download_file(url, output_path):
+            calls.append((url, output_path))
+
+        with patch("novus_pytils.files.download_file", fake_download_file):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["download", "https://example.com/files/audio.wav", "."])
+
+        assert len(calls) == 1
+        url, output_path = calls[0]
+        assert url == "https://example.com/files/audio.wav"
+        assert output_path.endswith("audio.wav")
+
+    def test_download_uses_default_filename_when_url_has_no_path(self, tmp_path, monkeypatch):
+        """Test that download uses 'downloaded_file' when URL has no filename."""
+        monkeypatch.chdir(tmp_path)
+
+        calls = []
+        def fake_download_file(url, output_path):
+            calls.append((url, output_path))
+
+        with patch("novus_pytils.files.download_file", fake_download_file):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["download", "https://example.com", str(tmp_path)])
+
+        assert len(calls) == 1
+        url, output_path = calls[0]
+        assert url == "https://example.com"
+        assert output_path.endswith("downloaded_file")
+
+    def test_download_uses_default_filename_when_url_ends_with_slash(self, tmp_path, monkeypatch):
+        """Test that download uses 'downloaded_file' when URL ends with slash."""
+        monkeypatch.chdir(tmp_path)
+
+        calls = []
+        def fake_download_file(url, output_path):
+            calls.append((url, output_path))
+
+        with patch("novus_pytils.files.download_file", fake_download_file):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["download", "https://example.com/folder/", str(tmp_path)])
+
+        assert len(calls) == 1
+        url, output_path = calls[0]
+        assert url == "https://example.com/folder/"
+        assert output_path.endswith("downloaded_file")
+
+    def test_download_resolves_dot_to_cwd(self, tmp_path, monkeypatch):
+        """Test that '.' output_dir resolves to current working directory."""
+        monkeypatch.chdir(tmp_path)
+
+        calls = []
+        def fake_download_file(url, output_path):
+            calls.append((url, output_path))
+
+        with patch("novus_pytils.files.download_file", fake_download_file):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["download", "https://example.com/test.zip", "."])
+
+        assert len(calls) == 1
+        url, output_path = calls[0]
+        assert os.path.dirname(output_path) == str(tmp_path)
+        assert output_path.endswith("test.zip")
+
+    def test_download_preserves_file_extension(self, tmp_path, monkeypatch):
+        """Test that file extensions are preserved from URL."""
+        monkeypatch.chdir(tmp_path)
+
+        calls = []
+        def fake_download_file(url, output_path):
+            calls.append((url, output_path))
+
+        with patch("novus_pytils.files.download_file", fake_download_file):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["download", "https://example.com/data/archive.tar.gz", str(tmp_path)])
+
+        assert len(calls) == 1
+        url, output_path = calls[0]
+        # Note: os.path.basename only gets the last component, so tar.gz becomes archive.tar.gz
+        assert output_path.endswith("archive.tar.gz")
+
+    def test_download_handles_query_params_in_url(self, tmp_path, monkeypatch):
+        """Test that URL query parameters don't affect filename extraction."""
+        monkeypatch.chdir(tmp_path)
+
+        calls = []
+        def fake_download_file(url, output_path):
+            calls.append((url, output_path))
+
+        with patch("novus_pytils.files.download_file", fake_download_file):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["download", "https://example.com/file.wav?token=abc123", str(tmp_path)])
+
+        assert len(calls) == 1
+        url, output_path = calls[0]
+        # The filename should be extracted without query params
+        assert "file.wav" in output_path
+        # The full URL with params should still be passed to download_file
+        assert url == "https://example.com/file.wav?token=abc123"

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -1,0 +1,431 @@
+"""
+Unit tests for bioamla.core.datasets module.
+"""
+
+import csv
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from bioamla.core.datasets import convert_filetype
+from bioamla.core.metadata import read_metadata_csv, write_metadata_csv
+
+
+def write_test_metadata(csv_path: Path, rows: list):
+    """Helper to write test metadata CSV."""
+    if not rows:
+        return
+    fieldnames = list(rows[0].keys())
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+class TestConvertFiletype:
+    """Tests for convert_filetype function."""
+
+    def test_no_converter_removes_row_and_deletes_source(self, temp_dir):
+        """No converter: row removed from metadata, source file deleted."""
+        # Create dataset structure
+        audio_dir = temp_dir / "species_a"
+        audio_dir.mkdir()
+
+        # Create source file with unsupported extension for conversion to flac
+        source_file = audio_dir / "test_audio.xyz"
+        source_file.write_bytes(b"dummy-audio-data")
+
+        # Create metadata
+        metadata_path = temp_dir / "metadata.csv"
+        rows = [
+            {
+                "file_name": "species_a/test_audio.xyz",
+                "split": "train",
+                "target": "1",
+                "category": "species_a",
+                "attr_id": "user1",
+                "attr_lic": "CC-BY",
+                "attr_url": "https://example.com/1",
+                "attr_note": ""
+            }
+        ]
+        write_test_metadata(metadata_path, rows)
+
+        # Mock _get_converter to return None (no converter available)
+        with patch("bioamla.core.datasets._get_converter", return_value=None):
+            stats = convert_filetype(
+                dataset_path=str(temp_dir),
+                target_format="wav",
+                verbose=False
+            )
+
+        # Verify row was removed from metadata
+        updated_rows, _ = read_metadata_csv(metadata_path)
+        assert len(updated_rows) == 0
+
+        # Verify source file was deleted
+        assert not source_file.exists()
+
+        # Verify stats
+        assert stats["files_failed"] == 1
+        assert stats["files_converted"] == 0
+
+    def test_missing_source_removes_row_no_new_file(self, temp_dir):
+        """Missing source: row removed, no new file created."""
+        # Create metadata pointing to non-existent file
+        metadata_path = temp_dir / "metadata.csv"
+        rows = [
+            {
+                "file_name": "missing_dir/missing_file.mp3",
+                "split": "train",
+                "target": "1",
+                "category": "species_a",
+                "attr_id": "user1",
+                "attr_lic": "CC-BY",
+                "attr_url": "https://example.com/1",
+                "attr_note": ""
+            }
+        ]
+        write_test_metadata(metadata_path, rows)
+
+        # Mock _get_converter to return a valid converter
+        mock_converter = MagicMock()
+        with patch("bioamla.core.datasets._get_converter", return_value=mock_converter):
+            stats = convert_filetype(
+                dataset_path=str(temp_dir),
+                target_format="wav",
+                verbose=False
+            )
+
+        # Verify row was removed from metadata
+        updated_rows, _ = read_metadata_csv(metadata_path)
+        assert len(updated_rows) == 0
+
+        # Verify no converted file was created
+        converted_path = temp_dir / "missing_dir" / "missing_file.wav"
+        assert not converted_path.exists()
+
+        # Verify converter was never called
+        mock_converter.assert_not_called()
+
+        # Verify stats
+        assert stats["files_failed"] == 1
+        assert stats["files_converted"] == 0
+
+    def test_conversion_error_removes_row_and_deletes_source(self, temp_dir):
+        """Conversion error: row removed from metadata, source file deleted."""
+        # Create dataset structure
+        audio_dir = temp_dir / "species_a"
+        audio_dir.mkdir()
+
+        # Create source file
+        source_file = audio_dir / "error_file.mp3"
+        source_file.write_bytes(b"dummy-audio-data")
+
+        # Create metadata
+        metadata_path = temp_dir / "metadata.csv"
+        rows = [
+            {
+                "file_name": "species_a/error_file.mp3",
+                "split": "train",
+                "target": "1",
+                "category": "species_a",
+                "attr_id": "user1",
+                "attr_lic": "CC-BY",
+                "attr_url": "https://example.com/1",
+                "attr_note": ""
+            }
+        ]
+        write_test_metadata(metadata_path, rows)
+
+        # Mock _get_converter to return a failing converter
+        def failing_converter(src, dst):
+            raise RuntimeError("Conversion failed!")
+
+        with patch("bioamla.core.datasets._get_converter", return_value=failing_converter):
+            stats = convert_filetype(
+                dataset_path=str(temp_dir),
+                target_format="wav",
+                verbose=False
+            )
+
+        # Verify row was removed from metadata
+        updated_rows, _ = read_metadata_csv(metadata_path)
+        assert len(updated_rows) == 0
+
+        # Verify source file was deleted
+        assert not source_file.exists()
+
+        # Verify converted file was not created
+        converted_path = audio_dir / "error_file.wav"
+        assert not converted_path.exists()
+
+        # Verify stats
+        assert stats["files_failed"] == 1
+        assert stats["files_converted"] == 0
+
+    def test_successful_conversion_updates_row_and_deletes_old(self, temp_dir):
+        """Successful conversion: row updated and old file removed when keep_original=False."""
+        # Create dataset structure
+        audio_dir = temp_dir / "species_a"
+        audio_dir.mkdir()
+
+        # Create source file
+        source_file = audio_dir / "success_file.mp3"
+        source_file.write_bytes(b"dummy-audio-data")
+
+        # Create metadata
+        metadata_path = temp_dir / "metadata.csv"
+        rows = [
+            {
+                "file_name": "species_a/success_file.mp3",
+                "split": "train",
+                "target": "1",
+                "category": "species_a",
+                "attr_id": "user1",
+                "attr_lic": "CC-BY",
+                "attr_url": "https://example.com/1",
+                "attr_note": ""
+            }
+        ]
+        write_test_metadata(metadata_path, rows)
+
+        # Mock _get_converter to return a successful converter
+        def successful_converter(src, dst):
+            Path(dst).write_bytes(b"converted-audio-data")
+
+        with patch("bioamla.core.datasets._get_converter", return_value=successful_converter):
+            stats = convert_filetype(
+                dataset_path=str(temp_dir),
+                target_format="wav",
+                keep_original=False,
+                verbose=False
+            )
+
+        # Verify row was updated in metadata
+        updated_rows, _ = read_metadata_csv(metadata_path)
+        assert len(updated_rows) == 1
+        assert updated_rows[0]["file_name"] == "species_a/success_file.wav"
+        assert updated_rows[0]["attr_note"] == "modified clip from original source"
+
+        # Verify converted file was created
+        converted_path = audio_dir / "success_file.wav"
+        assert converted_path.exists()
+
+        # Verify old source file was deleted
+        assert not source_file.exists()
+
+        # Verify stats
+        assert stats["files_converted"] == 1
+        assert stats["files_failed"] == 0
+
+    def test_successful_conversion_keeps_original_when_requested(self, temp_dir):
+        """Successful conversion with keep_original=True preserves source file."""
+        # Create dataset structure
+        audio_dir = temp_dir / "species_a"
+        audio_dir.mkdir()
+
+        # Create source file
+        source_file = audio_dir / "keep_file.mp3"
+        source_file.write_bytes(b"dummy-audio-data")
+
+        # Create metadata
+        metadata_path = temp_dir / "metadata.csv"
+        rows = [
+            {
+                "file_name": "species_a/keep_file.mp3",
+                "split": "train",
+                "target": "1",
+                "category": "species_a",
+                "attr_id": "user1",
+                "attr_lic": "CC-BY",
+                "attr_url": "https://example.com/1",
+                "attr_note": ""
+            }
+        ]
+        write_test_metadata(metadata_path, rows)
+
+        # Mock _get_converter to return a successful converter
+        def successful_converter(src, dst):
+            Path(dst).write_bytes(b"converted-audio-data")
+
+        with patch("bioamla.core.datasets._get_converter", return_value=successful_converter):
+            stats = convert_filetype(
+                dataset_path=str(temp_dir),
+                target_format="wav",
+                keep_original=True,
+                verbose=False
+            )
+
+        # Verify converted file was created
+        converted_path = audio_dir / "keep_file.wav"
+        assert converted_path.exists()
+
+        # Verify source file was kept
+        assert source_file.exists()
+
+        # Verify stats
+        assert stats["files_converted"] == 1
+
+    def test_skips_files_already_in_target_format(self, temp_dir):
+        """Files already in target format are skipped without modification."""
+        # Create dataset structure
+        audio_dir = temp_dir / "species_a"
+        audio_dir.mkdir()
+
+        # Create source file already in target format
+        source_file = audio_dir / "already_wav.wav"
+        source_file.write_bytes(b"wav-audio-data")
+
+        # Create metadata
+        metadata_path = temp_dir / "metadata.csv"
+        rows = [
+            {
+                "file_name": "species_a/already_wav.wav",
+                "split": "train",
+                "target": "1",
+                "category": "species_a",
+                "attr_id": "user1",
+                "attr_lic": "CC-BY",
+                "attr_url": "https://example.com/1",
+                "attr_note": "original note"
+            }
+        ]
+        write_test_metadata(metadata_path, rows)
+
+        mock_converter = MagicMock()
+        with patch("bioamla.core.datasets._get_converter", return_value=mock_converter):
+            stats = convert_filetype(
+                dataset_path=str(temp_dir),
+                target_format="wav",
+                verbose=False
+            )
+
+        # Verify row was preserved unchanged
+        updated_rows, _ = read_metadata_csv(metadata_path)
+        assert len(updated_rows) == 1
+        assert updated_rows[0]["file_name"] == "species_a/already_wav.wav"
+        assert updated_rows[0]["attr_note"] == "original note"
+
+        # Verify source file still exists
+        assert source_file.exists()
+
+        # Verify converter was never called
+        mock_converter.assert_not_called()
+
+        # Verify stats
+        assert stats["files_skipped"] == 1
+        assert stats["files_converted"] == 0
+
+    def test_handles_mixed_success_and_failure(self, temp_dir):
+        """Test handling of mixed successful and failed conversions."""
+        # Create dataset structure
+        audio_dir = temp_dir / "species_a"
+        audio_dir.mkdir()
+
+        # Create source files
+        success_file = audio_dir / "success.mp3"
+        success_file.write_bytes(b"success-audio-data")
+
+        fail_file = audio_dir / "fail.mp3"
+        fail_file.write_bytes(b"fail-audio-data")
+
+        skip_file = audio_dir / "skip.wav"
+        skip_file.write_bytes(b"skip-audio-data")
+
+        # Create metadata
+        metadata_path = temp_dir / "metadata.csv"
+        rows = [
+            {
+                "file_name": "species_a/success.mp3",
+                "split": "train",
+                "target": "1",
+                "category": "species_a",
+                "attr_id": "user1",
+                "attr_lic": "CC-BY",
+                "attr_url": "https://example.com/1",
+                "attr_note": ""
+            },
+            {
+                "file_name": "species_a/fail.mp3",
+                "split": "train",
+                "target": "1",
+                "category": "species_a",
+                "attr_id": "user2",
+                "attr_lic": "CC-BY",
+                "attr_url": "https://example.com/2",
+                "attr_note": ""
+            },
+            {
+                "file_name": "species_a/skip.wav",
+                "split": "train",
+                "target": "1",
+                "category": "species_a",
+                "attr_id": "user3",
+                "attr_lic": "CC-BY",
+                "attr_url": "https://example.com/3",
+                "attr_note": ""
+            }
+        ]
+        write_test_metadata(metadata_path, rows)
+
+        # Track which files the converter was called with
+        call_count = [0]
+
+        def mixed_converter(src, dst):
+            call_count[0] += 1
+            if "fail" in src:
+                raise RuntimeError("Intentional failure")
+            Path(dst).write_bytes(b"converted-audio-data")
+
+        with patch("bioamla.core.datasets._get_converter", return_value=mixed_converter):
+            stats = convert_filetype(
+                dataset_path=str(temp_dir),
+                target_format="wav",
+                verbose=False
+            )
+
+        # Verify metadata has correct rows (success + skip, not fail)
+        updated_rows, _ = read_metadata_csv(metadata_path)
+        assert len(updated_rows) == 2
+
+        file_names = [row["file_name"] for row in updated_rows]
+        assert "species_a/success.wav" in file_names
+        assert "species_a/skip.wav" in file_names
+        assert "species_a/fail.mp3" not in file_names
+        assert "species_a/fail.wav" not in file_names
+
+        # Verify stats
+        assert stats["files_converted"] == 1
+        assert stats["files_failed"] == 1
+        assert stats["files_skipped"] == 1
+
+    def test_invalid_target_format_raises_error(self, temp_dir):
+        """Test that invalid target format raises ValueError."""
+        metadata_path = temp_dir / "metadata.csv"
+        write_test_metadata(metadata_path, [{"file_name": "test.mp3"}])
+
+        with pytest.raises(ValueError, match="Unsupported target format"):
+            convert_filetype(
+                dataset_path=str(temp_dir),
+                target_format="invalid_format",
+                verbose=False
+            )
+
+    def test_missing_dataset_path_raises_error(self):
+        """Test that non-existent dataset path raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            convert_filetype(
+                dataset_path="/nonexistent/path",
+                target_format="wav",
+                verbose=False
+            )
+
+    def test_missing_metadata_raises_error(self, temp_dir):
+        """Test that missing metadata file raises ValueError."""
+        with pytest.raises(ValueError, match="Metadata file not found"):
+            convert_filetype(
+                dataset_path=str(temp_dir),
+                target_format="wav",
+                verbose=False
+            )


### PR DESCRIPTION
## Summary by Sourcery

Improve dataset splitting robustness, taxon handling, metadata writing behavior, and AST model loading, while expanding examples and adding unit tests.

Bug Fixes:
- Make audio dataset train/test splitting fall back gracefully from stratified to regular split when stratification is not possible.
- Ensure metadata CSV writing correctly clears existing files when given no rows and not merging.
- Fix AST pretrained model loading to correctly distinguish local paths from HuggingFace repo IDs by checking filesystem existence instead of path separators.

Enhancements:
- Normalize subspecies and similar ranks to their parent species name when downloading iNaturalist audio to group observations more consistently.
- Update the iNaturalist workflow example to use more observations per taxon and more training epochs for AST fine-tuning.

Tests:
- Add comprehensive unit tests for dataset audio file conversion and metadata interactions.
- Add unit tests for the CLI download command's URL-to-filename and output path resolution.
- Add unit tests for AST model loading path handling to cover local paths and remote model IDs.