### PR TITLE
0.0.47

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioamla"
-version = "0.0.45"
+version = "0.0.46"
 authors = [
   { name="John McMeen", email="johnmcmeen@gmail.com" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioamla"
-version = "0.0.46"
+version = "0.0.47"
 authors = [
   { name="John McMeen", email="johnmcmeen@gmail.com" },
 ]

--- a/src/bioamla/cli.py
+++ b/src/bioamla/cli.py
@@ -615,7 +615,7 @@ def wave(filepath: str):
 @click.option('--user-id', default=None, help='Filter by observer username')
 @click.option('--project-id', default=None, help='Filter by iNaturalist project ID or slug')
 @click.option('--quality-grade', default='research', help='Quality grade: research, needs_id, or casual')
-@click.option('--sound-license', default=None, help='Filter by sound license (e.g., cc-by, cc-by-nc, cc0)')
+@click.option('--sound-license', default=None, help='Comma-separated list of sound licenses (e.g., "cc-by, cc-by-nc, cc0")')
 @click.option('--start-date', default=None, help='Start date for observations (YYYY-MM-DD)')
 @click.option('--end-date', default=None, help='End date for observations (YYYY-MM-DD)')
 @click.option('--obs-per-taxon', type=int, default=100, help='Number of observations to download per taxon ID')
@@ -655,8 +655,8 @@ def inat_audio(
         Download bird sounds from the US:
         bioamla inat-audio ./birds --taxon-id 3 --place-id 1
 
-        Download frog sounds with specific license:
-        bioamla inat-audio ./frogs --taxon-name Anura --sound-license cc-by
+        Download frog sounds with specific licenses:
+        bioamla inat-audio ./frogs --taxon-name Anura --sound-license "cc-by, cc-by-nc, cc0"
 
         Download from a CSV file of taxon IDs:
         bioamla inat-audio ./sounds --taxon-csv taxa.csv --obs-per-taxon 10
@@ -676,6 +676,11 @@ def inat_audio(
     if file_extensions:
         extensions_list = [ext.strip() for ext in file_extensions.split(",")]
 
+    # Parse comma-separated sound licenses into a list
+    sound_license_list = None
+    if sound_license:
+        sound_license_list = [lic.strip() for lic in sound_license.split(",")]
+
     stats = download_inat_audio(
         output_dir=output_dir,
         taxon_ids=taxon_ids_list,
@@ -685,7 +690,7 @@ def inat_audio(
         user_id=user_id,
         project_id=project_id,
         quality_grade=quality_grade,
-        sound_license=sound_license,
+        sound_license=sound_license_list,
         d1=start_date,
         d2=end_date,
         obs_per_taxon=obs_per_taxon,

--- a/src/bioamla/core/inat.py
+++ b/src/bioamla/core/inat.py
@@ -111,7 +111,7 @@ def download_inat_audio(
     user_id: Optional[str] = None,
     project_id: Optional[str] = None,
     quality_grade: Optional[str] = "research",
-    sound_license: Optional[str] = None,
+    sound_license: Optional[List[str]] = None,
     d1: Optional[str] = None,
     d2: Optional[str] = None,
     obs_per_taxon: int = 100,
@@ -139,7 +139,7 @@ def download_inat_audio(
         user_id: Filter by observer username
         project_id: Filter by iNaturalist project ID or slug (e.g., "appalachia-bioacoustics")
         quality_grade: Filter by quality grade ("research", "needs_id", or "casual")
-        sound_license: Filter by sound license (e.g., "cc-by", "cc-by-nc", "cc0")
+        sound_license: Filter by sound license(s) (e.g., ["cc-by", "cc-by-nc", "cc0"])
         d1: Start date for observation date range (YYYY-MM-DD format)
         d2: End date for observation date range (YYYY-MM-DD format)
         obs_per_taxon: Number of observations to download per taxon ID
@@ -214,7 +214,9 @@ def download_inat_audio(
         print(f"Found {len(existing_files)} existing files in collection, will skip duplicates.")
 
     # Normalize sound_license to uppercase for pyinaturalist API compatibility
-    normalized_license = sound_license.upper() if sound_license else None
+    normalized_license = None
+    if sound_license:
+        normalized_license = [lic.upper() for lic in sound_license]
 
     # Normalize file extensions (ensure they start with a dot and are lowercase)
     normalized_extensions = None


### PR DESCRIPTION
## Summary by Sourcery

Support filtering iNaturalist audio downloads by multiple sound licenses and bump the package version.

New Features:
- Allow the inat-audio CLI command to accept a comma-separated list of sound licenses for filtering downloads.

Enhancements:
- Update internal download_inat_audio API to work with a list of sound licenses and normalize them for the pyinaturalist API.
- Improve CLI help text and examples to describe multi-license filtering behavior.

Build:
- Bump project version from 0.0.45 to 0.0.47.