### PR TITLE
0.1.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,0 @@
-rm -rf dist
-python3 -m build
-python3 -m twine upload dist/*

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+# =============================================================================
+# Bioamla System Dependencies Installer
+# =============================================================================
+# This script installs system-level dependencies required by bioamla.
+# Run this BEFORE installing bioamla via pip.
+#
+# Usage:
+#   ./scripts/install-deps.sh          # Install all dependencies
+#   ./scripts/install-deps.sh --check  # Check what's installed
+#
+# Supported platforms:
+#   - Ubuntu/Debian (apt)
+#   - Fedora/RHEL/CentOS (dnf/yum)
+#   - macOS (Homebrew)
+#   - Arch Linux (pacman)
+# =============================================================================
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+print_status() {
+    echo -e "${GREEN}[✓]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[!]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[✗]${NC} $1"
+}
+
+print_header() {
+    echo ""
+    echo "=============================================="
+    echo " $1"
+    echo "=============================================="
+}
+
+# Detect OS
+detect_os() {
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        if command -v apt-get &> /dev/null; then
+            echo "debian"
+        elif command -v dnf &> /dev/null; then
+            echo "fedora"
+        elif command -v yum &> /dev/null; then
+            echo "rhel"
+        elif command -v pacman &> /dev/null; then
+            echo "arch"
+        else
+            echo "unknown-linux"
+        fi
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "macos"
+    else
+        echo "unknown"
+    fi
+}
+
+# Check if a command exists
+check_command() {
+    command -v "$1" &> /dev/null
+}
+
+# Check installed dependencies
+check_dependencies() {
+    print_header "Checking System Dependencies"
+
+    local all_installed=true
+
+    # FFmpeg
+    if check_command ffmpeg; then
+        print_status "FFmpeg: $(ffmpeg -version 2>&1 | head -n1)"
+    else
+        print_error "FFmpeg: Not installed"
+        all_installed=false
+    fi
+
+    # libsndfile (check via pkg-config or library presence)
+    if pkg-config --exists sndfile 2>/dev/null || \
+       [ -f /usr/lib/libsndfile.so ] || \
+       [ -f /usr/local/lib/libsndfile.dylib ] || \
+       [ -f /opt/homebrew/lib/libsndfile.dylib ]; then
+        print_status "libsndfile: Installed"
+    else
+        print_warning "libsndfile: May not be installed (soundfile pip package may still work)"
+    fi
+
+    # PortAudio
+    if pkg-config --exists portaudio-2.0 2>/dev/null || \
+       [ -f /usr/lib/libportaudio.so ] || \
+       [ -f /usr/local/lib/libportaudio.dylib ] || \
+       [ -f /opt/homebrew/lib/libportaudio.dylib ]; then
+        print_status "PortAudio: Installed"
+    else
+        print_warning "PortAudio: Not installed (needed for real-time audio recording)"
+        all_installed=false
+    fi
+
+    echo ""
+    if $all_installed; then
+        print_status "All required dependencies are installed!"
+    else
+        print_warning "Some dependencies are missing. Run this script without --check to install them."
+    fi
+}
+
+# Install on Debian/Ubuntu
+install_debian() {
+    print_header "Installing on Debian/Ubuntu"
+
+    print_status "Updating package lists..."
+    sudo apt-get update
+
+    print_status "Installing FFmpeg..."
+    sudo apt-get install -y ffmpeg
+
+    print_status "Installing libsndfile..."
+    sudo apt-get install -y libsndfile1 libsndfile1-dev
+
+    print_status "Installing PortAudio..."
+    sudo apt-get install -y portaudio19-dev
+
+    print_status "Installation complete!"
+}
+
+# Install on Fedora
+install_fedora() {
+    print_header "Installing on Fedora"
+
+    print_status "Installing FFmpeg..."
+    # FFmpeg may require RPM Fusion
+    if ! sudo dnf list installed ffmpeg &> /dev/null; then
+        print_warning "FFmpeg requires RPM Fusion repository. Attempting to enable..."
+        sudo dnf install -y \
+            https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
+            https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm \
+            2>/dev/null || true
+    fi
+    sudo dnf install -y ffmpeg ffmpeg-devel
+
+    print_status "Installing libsndfile..."
+    sudo dnf install -y libsndfile libsndfile-devel
+
+    print_status "Installing PortAudio..."
+    sudo dnf install -y portaudio portaudio-devel
+
+    print_status "Installation complete!"
+}
+
+# Install on RHEL/CentOS
+install_rhel() {
+    print_header "Installing on RHEL/CentOS"
+
+    print_status "Installing EPEL repository..."
+    sudo yum install -y epel-release
+
+    print_status "Installing FFmpeg..."
+    # FFmpeg may require additional repos on RHEL
+    sudo yum install -y ffmpeg ffmpeg-devel 2>/dev/null || \
+        print_warning "FFmpeg not available in default repos. Install manually or enable RPM Fusion."
+
+    print_status "Installing libsndfile..."
+    sudo yum install -y libsndfile libsndfile-devel
+
+    print_status "Installing PortAudio..."
+    sudo yum install -y portaudio portaudio-devel
+
+    print_status "Installation complete!"
+}
+
+# Install on Arch Linux
+install_arch() {
+    print_header "Installing on Arch Linux"
+
+    print_status "Installing dependencies..."
+    sudo pacman -S --noconfirm ffmpeg libsndfile portaudio
+
+    print_status "Installation complete!"
+}
+
+# Install on macOS
+install_macos() {
+    print_header "Installing on macOS"
+
+    # Check for Homebrew
+    if ! check_command brew; then
+        print_error "Homebrew not found. Please install Homebrew first:"
+        echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\""
+        exit 1
+    fi
+
+    print_status "Installing FFmpeg..."
+    brew install ffmpeg
+
+    print_status "Installing libsndfile..."
+    brew install libsndfile
+
+    print_status "Installing PortAudio..."
+    brew install portaudio
+
+    print_status "Installation complete!"
+}
+
+# Main
+main() {
+    echo "=============================================="
+    echo " Bioamla System Dependencies Installer"
+    echo "=============================================="
+
+    # Check-only mode
+    if [[ "$1" == "--check" ]]; then
+        check_dependencies
+        exit 0
+    fi
+
+    OS=$(detect_os)
+    echo "Detected OS: $OS"
+
+    case $OS in
+        debian)
+            install_debian
+            ;;
+        fedora)
+            install_fedora
+            ;;
+        rhel)
+            install_rhel
+            ;;
+        arch)
+            install_arch
+            ;;
+        macos)
+            install_macos
+            ;;
+        *)
+            print_error "Unsupported operating system: $OS"
+            echo ""
+            echo "Please install the following packages manually:"
+            echo "  - FFmpeg (for audio format conversion)"
+            echo "  - libsndfile (for audio file I/O)"
+            echo "  - PortAudio (for real-time audio recording)"
+            exit 1
+            ;;
+    esac
+
+    echo ""
+    print_header "Verification"
+    check_dependencies
+
+    echo ""
+    print_status "You can now install bioamla:"
+    echo "  pip install bioamla"
+}
+
+main "$@"

--- a/src/bioamla/deps.py
+++ b/src/bioamla/deps.py
@@ -1,0 +1,338 @@
+"""
+System dependency checking and installation for bioamla.
+
+This module provides utilities to check for and install system-level
+dependencies required by bioamla (FFmpeg, libsndfile, PortAudio).
+"""
+
+import platform
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class DependencyStatus:
+    """Status of a system dependency."""
+
+    name: str
+    description: str
+    required_for: str
+    installed: bool
+    version: Optional[str] = None
+    install_hint: Optional[str] = None
+
+
+def detect_os() -> str:
+    """Detect the operating system and package manager.
+
+    Returns:
+        One of: 'debian', 'fedora', 'rhel', 'arch', 'macos', 'windows', 'unknown'
+    """
+    system = platform.system().lower()
+
+    if system == "darwin":
+        return "macos"
+    elif system == "windows":
+        return "windows"
+    elif system == "linux":
+        # Check for package managers to identify distro family
+        if shutil.which("apt-get"):
+            return "debian"
+        elif shutil.which("dnf"):
+            return "fedora"
+        elif shutil.which("yum"):
+            return "rhel"
+        elif shutil.which("pacman"):
+            return "arch"
+        else:
+            return "unknown-linux"
+    else:
+        return "unknown"
+
+
+def check_ffmpeg() -> DependencyStatus:
+    """Check if FFmpeg is installed."""
+    version = None
+    installed = False
+
+    if shutil.which("ffmpeg"):
+        installed = True
+        try:
+            result = subprocess.run(
+                ["ffmpeg", "-version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            # Extract version from first line
+            first_line = result.stdout.split("\n")[0]
+            if "version" in first_line.lower():
+                version = first_line.split("version")[1].split()[0].strip()
+        except Exception:
+            pass
+
+    return DependencyStatus(
+        name="FFmpeg",
+        description="Audio format conversion",
+        required_for="MP3, FLAC, and other formats (WAV works without)",
+        installed=installed,
+        version=version,
+    )
+
+
+def check_libsndfile() -> DependencyStatus:
+    """Check if libsndfile is installed."""
+    installed = False
+    version = None
+
+    # Try pkg-config first
+    if shutil.which("pkg-config"):
+        try:
+            result = subprocess.run(
+                ["pkg-config", "--modversion", "sndfile"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                installed = True
+                version = result.stdout.strip()
+        except Exception:
+            pass
+
+    # Fallback: try importing soundfile (will fail if libsndfile missing)
+    if not installed:
+        try:
+            import soundfile
+
+            installed = True
+            version = getattr(soundfile, "__libsndfile_version__", "unknown")
+        except (ImportError, OSError):
+            pass
+
+    return DependencyStatus(
+        name="libsndfile",
+        description="Audio file I/O library",
+        required_for="Reading/writing audio files",
+        installed=installed,
+        version=version,
+    )
+
+
+def check_portaudio() -> DependencyStatus:
+    """Check if PortAudio is installed."""
+    installed = False
+    version = None
+
+    # Try pkg-config first
+    if shutil.which("pkg-config"):
+        try:
+            result = subprocess.run(
+                ["pkg-config", "--modversion", "portaudio-2.0"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                installed = True
+                version = result.stdout.strip()
+        except Exception:
+            pass
+
+    # Fallback: try importing sounddevice
+    if not installed:
+        try:
+            import sounddevice
+
+            installed = True
+            pa_version = sounddevice.query_hostapis()
+            if pa_version:
+                version = "available"
+        except (ImportError, OSError):
+            pass
+
+    return DependencyStatus(
+        name="PortAudio",
+        description="Audio hardware access",
+        required_for="Real-time recording (bioamla realtime commands)",
+        installed=installed,
+        version=version,
+    )
+
+
+def check_all_dependencies() -> list[DependencyStatus]:
+    """Check all system dependencies.
+
+    Returns:
+        List of DependencyStatus objects for each dependency.
+    """
+    os_type = detect_os()
+
+    deps = [
+        check_ffmpeg(),
+        check_libsndfile(),
+        check_portaudio(),
+    ]
+
+    # Add install hints based on OS
+    install_commands = get_install_commands(os_type)
+    for dep in deps:
+        dep.install_hint = install_commands.get(dep.name.lower())
+
+    return deps
+
+
+def get_install_commands(os_type: str) -> dict[str, str]:
+    """Get install commands for each dependency based on OS.
+
+    Args:
+        os_type: The detected OS type.
+
+    Returns:
+        Dict mapping dependency name to install command.
+    """
+    commands = {
+        "debian": {
+            "ffmpeg": "sudo apt install ffmpeg",
+            "libsndfile": "sudo apt install libsndfile1",
+            "portaudio": "sudo apt install portaudio19-dev",
+        },
+        "fedora": {
+            "ffmpeg": "sudo dnf install ffmpeg",
+            "libsndfile": "sudo dnf install libsndfile",
+            "portaudio": "sudo dnf install portaudio",
+        },
+        "rhel": {
+            "ffmpeg": "sudo yum install ffmpeg",
+            "libsndfile": "sudo yum install libsndfile",
+            "portaudio": "sudo yum install portaudio",
+        },
+        "arch": {
+            "ffmpeg": "sudo pacman -S ffmpeg",
+            "libsndfile": "sudo pacman -S libsndfile",
+            "portaudio": "sudo pacman -S portaudio",
+        },
+        "macos": {
+            "ffmpeg": "brew install ffmpeg",
+            "libsndfile": "brew install libsndfile",
+            "portaudio": "brew install portaudio",
+        },
+        "windows": {
+            "ffmpeg": "choco install ffmpeg  # or download from ffmpeg.org",
+            "libsndfile": "pip install soundfile  # usually bundled on Windows",
+            "portaudio": "pip install sounddevice  # usually bundled on Windows",
+        },
+    }
+
+    return commands.get(os_type, {})
+
+
+def get_full_install_command(os_type: str) -> Optional[str]:
+    """Get a single command to install all dependencies.
+
+    Args:
+        os_type: The detected OS type.
+
+    Returns:
+        Full install command string, or None if not available.
+    """
+    commands = {
+        "debian": "sudo apt install ffmpeg libsndfile1 portaudio19-dev",
+        "fedora": "sudo dnf install ffmpeg libsndfile portaudio",
+        "rhel": "sudo yum install ffmpeg libsndfile portaudio",
+        "arch": "sudo pacman -S ffmpeg libsndfile portaudio",
+        "macos": "brew install ffmpeg libsndfile portaudio",
+    }
+    return commands.get(os_type)
+
+
+def run_install(os_type: Optional[str] = None) -> tuple[bool, str]:
+    """Run the system dependency installation.
+
+    Args:
+        os_type: Override OS detection. If None, auto-detect.
+
+    Returns:
+        Tuple of (success, message).
+    """
+    if os_type is None:
+        os_type = detect_os()
+
+    if os_type == "windows":
+        return False, (
+            "Automatic installation not supported on Windows.\n"
+            "Please install manually:\n"
+            "  - FFmpeg: https://ffmpeg.org/download.html or 'choco install ffmpeg'\n"
+            "  - libsndfile and PortAudio are usually bundled with pip packages"
+        )
+
+    if os_type == "unknown" or os_type == "unknown-linux":
+        return False, (
+            "Could not detect your operating system.\n"
+            "Please install manually:\n"
+            "  - FFmpeg (for audio format support)\n"
+            "  - libsndfile (for audio file I/O)\n"
+            "  - PortAudio (for real-time recording)"
+        )
+
+    command = get_full_install_command(os_type)
+    if not command:
+        return False, f"No install command available for {os_type}"
+
+    # Check for required privileges on macOS (Homebrew doesn't need sudo)
+    if os_type != "macos" and not _has_sudo():
+        return False, (
+            f"Installation requires sudo privileges.\n"
+            f"Please run: {command}"
+        )
+
+    try:
+        # Split command for subprocess
+        if os_type == "macos":
+            # Homebrew command
+            result = subprocess.run(
+                ["brew", "install", "ffmpeg", "libsndfile", "portaudio"],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        else:
+            # Linux with sudo
+            parts = command.split()
+            result = subprocess.run(
+                parts,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+
+        if result.returncode == 0:
+            return True, "Dependencies installed successfully!"
+        else:
+            return False, f"Installation failed:\n{result.stderr}"
+
+    except subprocess.TimeoutExpired:
+        return False, "Installation timed out. Please run manually:\n" + command
+    except FileNotFoundError as e:
+        return False, f"Package manager not found: {e}\nPlease run manually:\n{command}"
+    except Exception as e:
+        return False, f"Installation failed: {e}\nPlease run manually:\n{command}"
+
+
+def _has_sudo() -> bool:
+    """Check if we can run sudo."""
+    if sys.platform == "win32":
+        return False
+
+    try:
+        result = subprocess.run(
+            ["sudo", "-n", "true"],
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False

--- a/tests/unit/test_cli_config_deps.py
+++ b/tests/unit/test_cli_config_deps.py
@@ -1,0 +1,81 @@
+"""
+Unit tests for the config deps CLI command.
+"""
+
+import pytest
+from click.testing import CliRunner
+
+from bioamla.cli import cli
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+class TestConfigDepsCommand:
+    """Tests for bioamla config deps command."""
+
+    def test_deps_shows_status(self, runner):
+        """Test that deps shows dependency status."""
+        result = runner.invoke(cli, ["config", "deps"])
+
+        assert result.exit_code == 0
+        assert "System Dependencies" in result.output
+        assert "Detected OS" in result.output
+
+    def test_deps_shows_all_dependencies(self, runner):
+        """Test that deps shows all three dependencies."""
+        result = runner.invoke(cli, ["config", "deps"])
+
+        assert result.exit_code == 0
+        assert "FFmpeg" in result.output
+        assert "libsndfile" in result.output
+        assert "PortAudio" in result.output
+
+    def test_deps_shows_descriptions(self, runner):
+        """Test that deps shows dependency descriptions."""
+        result = runner.invoke(cli, ["config", "deps"])
+
+        assert result.exit_code == 0
+        assert "Audio format conversion" in result.output
+        assert "Audio file I/O" in result.output
+        assert "Audio hardware" in result.output
+
+    def test_deps_help(self, runner):
+        """Test deps --help shows options."""
+        result = runner.invoke(cli, ["config", "deps", "--help"])
+
+        assert result.exit_code == 0
+        assert "--install" in result.output
+        assert "--yes" in result.output
+        assert "-y" in result.output
+
+    def test_deps_install_without_yes_prompts(self, runner):
+        """Test that --install without --yes would prompt for confirmation."""
+        # Use input='n' to simulate declining the prompt
+        result = runner.invoke(cli, ["config", "deps", "--install"], input="n\n")
+
+        # Should either prompt and exit, or proceed with install
+        # The behavior depends on whether there are missing deps
+        assert result.exit_code == 0 or "Aborted" in result.output or "cancelled" in result.output.lower()
+
+
+class TestConfigDepsHelp:
+    """Tests for config deps command help."""
+
+    def test_config_deps_in_config_help(self, runner):
+        """Test that deps appears in config --help."""
+        result = runner.invoke(cli, ["config", "--help"])
+
+        assert result.exit_code == 0
+        assert "deps" in result.output
+
+    def test_config_deps_description_in_help(self, runner):
+        """Test that deps has a description in config --help."""
+        result = runner.invoke(cli, ["config", "--help"])
+
+        assert result.exit_code == 0
+        # Should show description about system dependencies
+        assert "dependencies" in result.output.lower() or "FFmpeg" in result.output

--- a/tests/unit/test_deps.py
+++ b/tests/unit/test_deps.py
@@ -1,0 +1,305 @@
+"""
+Unit tests for the deps module (system dependency checking).
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from bioamla.deps import (
+    DependencyStatus,
+    detect_os,
+    check_ffmpeg,
+    check_libsndfile,
+    check_portaudio,
+    check_all_dependencies,
+    get_install_commands,
+    get_full_install_command,
+)
+
+
+class TestDetectOS:
+    """Tests for detect_os function."""
+
+    def test_detect_os_returns_string(self):
+        """Test that detect_os returns a string."""
+        result = detect_os()
+        assert isinstance(result, str)
+
+    def test_detect_os_known_values(self):
+        """Test that detect_os returns one of the known OS types."""
+        result = detect_os()
+        known_types = [
+            "debian",
+            "fedora",
+            "rhel",
+            "arch",
+            "macos",
+            "windows",
+            "unknown",
+            "unknown-linux",
+        ]
+        assert result in known_types
+
+    @patch("bioamla.deps.platform.system")
+    def test_detect_os_darwin(self, mock_system):
+        """Test detection of macOS."""
+        mock_system.return_value = "Darwin"
+        assert detect_os() == "macos"
+
+    @patch("bioamla.deps.platform.system")
+    def test_detect_os_windows(self, mock_system):
+        """Test detection of Windows."""
+        mock_system.return_value = "Windows"
+        assert detect_os() == "windows"
+
+    @patch("bioamla.deps.platform.system")
+    @patch("bioamla.deps.shutil.which")
+    def test_detect_os_debian(self, mock_which, mock_system):
+        """Test detection of Debian-based Linux."""
+        mock_system.return_value = "Linux"
+        mock_which.side_effect = lambda x: "/usr/bin/apt-get" if x == "apt-get" else None
+        assert detect_os() == "debian"
+
+    @patch("bioamla.deps.platform.system")
+    @patch("bioamla.deps.shutil.which")
+    def test_detect_os_fedora(self, mock_which, mock_system):
+        """Test detection of Fedora."""
+        mock_system.return_value = "Linux"
+        mock_which.side_effect = lambda x: "/usr/bin/dnf" if x == "dnf" else None
+        assert detect_os() == "fedora"
+
+    @patch("bioamla.deps.platform.system")
+    @patch("bioamla.deps.shutil.which")
+    def test_detect_os_arch(self, mock_which, mock_system):
+        """Test detection of Arch Linux."""
+        mock_system.return_value = "Linux"
+        mock_which.side_effect = lambda x: "/usr/bin/pacman" if x == "pacman" else None
+        assert detect_os() == "arch"
+
+    @patch("bioamla.deps.platform.system")
+    @patch("bioamla.deps.shutil.which")
+    def test_detect_os_unknown_linux(self, mock_which, mock_system):
+        """Test detection of unknown Linux."""
+        mock_system.return_value = "Linux"
+        mock_which.return_value = None
+        assert detect_os() == "unknown-linux"
+
+
+class TestCheckFFmpeg:
+    """Tests for check_ffmpeg function."""
+
+    def test_check_ffmpeg_returns_status(self):
+        """Test that check_ffmpeg returns a DependencyStatus."""
+        result = check_ffmpeg()
+        assert isinstance(result, DependencyStatus)
+
+    def test_check_ffmpeg_has_correct_name(self):
+        """Test that the status has the correct name."""
+        result = check_ffmpeg()
+        assert result.name == "FFmpeg"
+
+    def test_check_ffmpeg_has_description(self):
+        """Test that the status has a description."""
+        result = check_ffmpeg()
+        assert result.description == "Audio format conversion"
+
+    def test_check_ffmpeg_has_required_for(self):
+        """Test that the status has required_for info."""
+        result = check_ffmpeg()
+        assert "MP3" in result.required_for or "format" in result.required_for.lower()
+
+    @patch("bioamla.deps.shutil.which")
+    def test_check_ffmpeg_not_installed(self, mock_which):
+        """Test when FFmpeg is not installed."""
+        mock_which.return_value = None
+        result = check_ffmpeg()
+        assert result.installed is False
+        assert result.version is None
+
+
+class TestCheckLibsndfile:
+    """Tests for check_libsndfile function."""
+
+    def test_check_libsndfile_returns_status(self):
+        """Test that check_libsndfile returns a DependencyStatus."""
+        result = check_libsndfile()
+        assert isinstance(result, DependencyStatus)
+
+    def test_check_libsndfile_has_correct_name(self):
+        """Test that the status has the correct name."""
+        result = check_libsndfile()
+        assert result.name == "libsndfile"
+
+    def test_check_libsndfile_has_description(self):
+        """Test that the status has a description."""
+        result = check_libsndfile()
+        assert "Audio" in result.description or "I/O" in result.description
+
+
+class TestCheckPortaudio:
+    """Tests for check_portaudio function."""
+
+    def test_check_portaudio_returns_status(self):
+        """Test that check_portaudio returns a DependencyStatus."""
+        result = check_portaudio()
+        assert isinstance(result, DependencyStatus)
+
+    def test_check_portaudio_has_correct_name(self):
+        """Test that the status has the correct name."""
+        result = check_portaudio()
+        assert result.name == "PortAudio"
+
+    def test_check_portaudio_has_description(self):
+        """Test that the status has a description."""
+        result = check_portaudio()
+        assert "Audio" in result.description or "hardware" in result.description.lower()
+
+
+class TestCheckAllDependencies:
+    """Tests for check_all_dependencies function."""
+
+    def test_check_all_returns_list(self):
+        """Test that check_all_dependencies returns a list."""
+        result = check_all_dependencies()
+        assert isinstance(result, list)
+
+    def test_check_all_returns_three_deps(self):
+        """Test that check_all_dependencies returns exactly 3 dependencies."""
+        result = check_all_dependencies()
+        assert len(result) == 3
+
+    def test_check_all_returns_status_objects(self):
+        """Test that all items are DependencyStatus objects."""
+        result = check_all_dependencies()
+        for dep in result:
+            assert isinstance(dep, DependencyStatus)
+
+    def test_check_all_includes_all_deps(self):
+        """Test that all expected dependencies are included."""
+        result = check_all_dependencies()
+        names = [dep.name for dep in result]
+        assert "FFmpeg" in names
+        assert "libsndfile" in names
+        assert "PortAudio" in names
+
+    def test_check_all_has_install_hints(self):
+        """Test that dependencies have install hints populated."""
+        result = check_all_dependencies()
+        # At least one should have an install hint on any supported OS
+        has_hints = any(dep.install_hint is not None for dep in result)
+        # This might be False on unknown OS, so we just verify the structure
+        for dep in result:
+            assert hasattr(dep, "install_hint")
+
+
+class TestGetInstallCommands:
+    """Tests for get_install_commands function."""
+
+    def test_debian_commands(self):
+        """Test install commands for Debian."""
+        commands = get_install_commands("debian")
+        assert "apt" in commands.get("ffmpeg", "")
+        assert "apt" in commands.get("libsndfile", "")
+        assert "apt" in commands.get("portaudio", "")
+
+    def test_fedora_commands(self):
+        """Test install commands for Fedora."""
+        commands = get_install_commands("fedora")
+        assert "dnf" in commands.get("ffmpeg", "")
+        assert "dnf" in commands.get("libsndfile", "")
+        assert "dnf" in commands.get("portaudio", "")
+
+    def test_arch_commands(self):
+        """Test install commands for Arch."""
+        commands = get_install_commands("arch")
+        assert "pacman" in commands.get("ffmpeg", "")
+        assert "pacman" in commands.get("libsndfile", "")
+        assert "pacman" in commands.get("portaudio", "")
+
+    def test_macos_commands(self):
+        """Test install commands for macOS."""
+        commands = get_install_commands("macos")
+        assert "brew" in commands.get("ffmpeg", "")
+        assert "brew" in commands.get("libsndfile", "")
+        assert "brew" in commands.get("portaudio", "")
+
+    def test_windows_commands(self):
+        """Test install commands for Windows."""
+        commands = get_install_commands("windows")
+        assert "ffmpeg" in commands
+        assert "libsndfile" in commands
+        assert "portaudio" in commands
+
+    def test_unknown_os_returns_empty(self):
+        """Test that unknown OS returns empty dict."""
+        commands = get_install_commands("unknown")
+        assert commands == {}
+
+
+class TestGetFullInstallCommand:
+    """Tests for get_full_install_command function."""
+
+    def test_debian_full_command(self):
+        """Test full install command for Debian."""
+        command = get_full_install_command("debian")
+        assert command is not None
+        assert "apt" in command
+        assert "ffmpeg" in command
+        assert "libsndfile" in command
+        assert "portaudio" in command
+
+    def test_fedora_full_command(self):
+        """Test full install command for Fedora."""
+        command = get_full_install_command("fedora")
+        assert command is not None
+        assert "dnf" in command
+
+    def test_macos_full_command(self):
+        """Test full install command for macOS."""
+        command = get_full_install_command("macos")
+        assert command is not None
+        assert "brew" in command
+
+    def test_windows_returns_none(self):
+        """Test that Windows returns None (no full command)."""
+        command = get_full_install_command("windows")
+        assert command is None
+
+    def test_unknown_returns_none(self):
+        """Test that unknown OS returns None."""
+        command = get_full_install_command("unknown")
+        assert command is None
+
+
+class TestDependencyStatus:
+    """Tests for DependencyStatus dataclass."""
+
+    def test_create_status(self):
+        """Test creating a DependencyStatus."""
+        status = DependencyStatus(
+            name="Test",
+            description="Test description",
+            required_for="Testing",
+            installed=True,
+            version="1.0.0",
+            install_hint="apt install test",
+        )
+        assert status.name == "Test"
+        assert status.description == "Test description"
+        assert status.required_for == "Testing"
+        assert status.installed is True
+        assert status.version == "1.0.0"
+        assert status.install_hint == "apt install test"
+
+    def test_create_status_minimal(self):
+        """Test creating a DependencyStatus with minimal fields."""
+        status = DependencyStatus(
+            name="Test",
+            description="Test description",
+            required_for="Testing",
+            installed=False,
+        )
+        assert status.name == "Test"
+        assert status.installed is False
+        assert status.version is None
+        assert status.install_hint is None


### PR DESCRIPTION
## Summary by Sourcery

Add a CLI command and supporting utilities to check and install system-level audio dependencies required by bioamla, along with tests and a helper installation script.

New Features:
- Introduce bioamla config deps command to inspect and optionally install required system audio dependencies (FFmpeg, libsndfile, PortAudio).
- Add a deps module to detect OS, check dependency presence/versions, and generate install commands for common platforms.
- Provide a shell script to install bioamla system dependencies on major Linux distributions and macOS.

Build:
- Remove the legacy build.sh script in favor of the new installation tooling.

Tests:
- Add unit tests for the deps module covering OS detection, dependency checks, and install command generation.
- Add CLI tests for the new config deps command, including help output and basic interaction paths.