### PR TITLE
adding service factory

### DIFF
--- a/src/bioamla/cli/service_helpers.py
+++ b/src/bioamla/cli/service_helpers.py
@@ -1,0 +1,165 @@
+"""
+CLI Service Helpers
+===================
+
+CLI-specific utilities for working with services and the ServiceFactory.
+
+This module provides convenience functions for CLI commands to:
+1. Access a singleton ServiceFactory instance
+2. Handle service result errors consistently
+3. Reduce boilerplate in command implementations
+
+Architecture:
+- Module-level singleton factory for consistent service instances across CLI
+- Error handling utilities for consistent user feedback
+- CLI-specific conveniences without polluting the reusable ServiceFactory
+
+Usage:
+    from bioamla.cli.service_helpers import services, handle_result
+
+    # Access services via singleton factory
+    audio_file_svc = services.audio_file
+    result = audio_file_svc.open("file.wav")
+
+    # Handle result with automatic error reporting
+    audio_data = handle_result(result)  # Exits with error message if failed
+
+    # Or manually check
+    if not result.success:
+        exit_with_error(result.error)
+"""
+
+from typing import Any, TypeVar
+
+import click
+
+from bioamla.services import ServiceFactory
+from bioamla.services.base import ServiceResult
+
+# Type variable for generic result handling
+T = TypeVar("T")
+
+
+# ============================================================================
+# Singleton Factory Instance
+# ============================================================================
+
+# Module-level singleton factory for CLI commands
+# All CLI commands share this factory instance for consistency
+_factory: ServiceFactory | None = None
+
+
+def get_factory() -> ServiceFactory:
+    """
+    Get the singleton ServiceFactory instance for CLI.
+
+    Returns:
+        ServiceFactory: The singleton factory instance with LocalFileRepository
+    """
+    global _factory
+    if _factory is None:
+        _factory = ServiceFactory()
+    return _factory
+
+
+# Convenient alias for CLI commands
+services = get_factory()
+
+
+# ============================================================================
+# Result Handling Utilities
+# ============================================================================
+
+
+def handle_result(result: ServiceResult[T]) -> T:
+    """
+    Handle a service result, exiting with error if failed.
+
+    This is a convenience function for CLI commands that want to
+    automatically handle errors and extract the data from successful results.
+
+    Args:
+        result: Service result to handle
+
+    Returns:
+        The result data if successful
+
+    Raises:
+        SystemExit: If result indicates failure (exits with code 1)
+
+    Example:
+        result = services.audio_file.open("file.wav")
+        audio_data = handle_result(result)  # Auto-exits on error
+        # Use audio_data...
+    """
+    if not result.success:
+        exit_with_error(result.error or "Unknown error")
+    return result.data
+
+
+def exit_with_error(message: str, code: int = 1) -> None:
+    """
+    Print error message and exit.
+
+    Args:
+        message: Error message to display
+        code: Exit code (default: 1)
+
+    Raises:
+        SystemExit: Always exits with specified code
+    """
+    click.echo(f"Error: {message}", err=True)
+    raise SystemExit(code)
+
+
+def check_result(result: ServiceResult[Any], error_message: str | None = None) -> bool:
+    """
+    Check if a result is successful, exit with error if not.
+
+    This is useful when you don't need the result data, only to verify success.
+
+    Args:
+        result: Service result to check
+        error_message: Optional custom error message (uses result.error if None)
+
+    Returns:
+        True if successful (always returns True, exits otherwise)
+
+    Raises:
+        SystemExit: If result indicates failure (exits with code 1)
+
+    Example:
+        result = services.file.write_json(data, "output.json")
+        check_result(result)  # Exits if failed
+        click.echo("Success!")
+    """
+    if not result.success:
+        msg = error_message or result.error or "Unknown error"
+        exit_with_error(msg)
+    return True
+
+
+# ============================================================================
+# Factory Reset (for testing)
+# ============================================================================
+
+
+def reset_factory() -> None:
+    """
+    Reset the singleton factory instance.
+
+    This is primarily useful for testing to ensure a clean factory state.
+    Normal CLI commands should not need to call this.
+    """
+    global _factory
+    _factory = None
+
+
+__all__ = [
+    "services",
+    "get_factory",
+    "handle_result",
+    "exit_with_error",
+    "check_result",
+    "reset_factory",
+]

--- a/src/bioamla/services/factory.py
+++ b/src/bioamla/services/factory.py
@@ -204,5 +204,144 @@ class ServiceFactory:
         """Create BatchClusteringService with file repository."""
         return BatchClusteringService(file_repository=self.file_repository)
 
+    # ========================================================================
+    # Property-Based Access (Convenience for CLI and other applications)
+    # ========================================================================
+
+    @property
+    def audio_file(self) -> AudioFileService:
+        """Convenience property for create_audio_file_service()."""
+        return self.create_audio_file_service()
+
+    @property
+    def audio_transform(self) -> AudioTransformService:
+        """Convenience property for create_audio_transform_service()."""
+        return self.create_audio_transform_service()
+
+    @property
+    def file(self) -> FileService:
+        """Convenience property for create_file_service()."""
+        return self.create_file_service()
+
+    @property
+    def dataset(self) -> DatasetService:
+        """Convenience property for create_dataset_service()."""
+        return self.create_dataset_service()
+
+    @property
+    def annotation(self) -> AnnotationService:
+        """Convenience property for create_annotation_service()."""
+        return self.create_annotation_service()
+
+    @property
+    def detection(self) -> DetectionService:
+        """Convenience property for create_detection_service()."""
+        return self.create_detection_service()
+
+    @property
+    def indices(self) -> IndicesService:
+        """Convenience property for create_indices_service()."""
+        return self.create_indices_service()
+
+    @property
+    def ribbit(self) -> RibbitService:
+        """Convenience property for create_ribbit_service()."""
+        return self.create_ribbit_service()
+
+    @property
+    def embedding(self) -> EmbeddingService:
+        """Convenience property for create_embedding_service()."""
+        return self.create_embedding_service()
+
+    @property
+    def inference(self) -> InferenceService:
+        """Convenience property for create_inference_service()."""
+        return self.create_inference_service()
+
+    @property
+    def ast(self) -> ASTService:
+        """Convenience property for create_ast_service()."""
+        return self.create_ast_service()
+
+    @property
+    def birdnet(self) -> BirdNETService:
+        """Convenience property for create_birdnet_service()."""
+        return self.create_birdnet_service()
+
+    @property
+    def cnn(self) -> CNNService:
+        """Convenience property for create_cnn_service()."""
+        return self.create_cnn_service()
+
+    @property
+    def inaturalist(self) -> INaturalistService:
+        """Convenience property for create_inaturalist_service()."""
+        return self.create_inaturalist_service()
+
+    @property
+    def xeno_canto(self) -> XenoCantoService:
+        """Convenience property for create_xeno_canto_service()."""
+        return self.create_xeno_canto_service()
+
+    @property
+    def macaulay(self) -> MacaulayService:
+        """Convenience property for create_macaulay_service()."""
+        return self.create_macaulay_service()
+
+    @property
+    def ebird(self) -> EBirdService:
+        """Convenience property for create_ebird_service()."""
+        return self.create_ebird_service()
+
+    @property
+    def huggingface(self) -> HuggingFaceService:
+        """Convenience property for create_huggingface_service()."""
+        return self.create_huggingface_service()
+
+    @property
+    def species(self) -> SpeciesService:
+        """Convenience property for create_species_service()."""
+        return self.create_species_service()
+
+    @property
+    def clustering(self) -> ClusteringService:
+        """Convenience property for create_clustering_service()."""
+        return self.create_clustering_service()
+
+    @property
+    def config(self) -> ConfigService:
+        """Convenience property for create_config_service()."""
+        return self.create_config_service()
+
+    @property
+    def dependency(self) -> DependencyService:
+        """Convenience property for create_dependency_service()."""
+        return self.create_dependency_service()
+
+    @property
+    def batch_audio_transform(self) -> BatchAudioTransformService:
+        """Convenience property for create_batch_audio_transform_service()."""
+        return self.create_batch_audio_transform_service()
+
+    @property
+    def batch_detection(self) -> BatchDetectionService:
+        """Convenience property for create_batch_detection_service()."""
+        return self.create_batch_detection_service()
+
+    @property
+    def batch_indices(self) -> BatchIndicesService:
+        """Convenience property for create_batch_indices_service()."""
+        return self.create_batch_indices_service()
+
+    @property
+    def batch_inference(self) -> BatchInferenceService:
+        """Convenience property for create_batch_inference_service()."""
+        return self.create_batch_inference_service()
+
+    @property
+    def batch_clustering(self) -> BatchClusteringService:
+        """Convenience property for create_batch_clustering_service()."""
+        return self.create_batch_clustering_service()
+
 
 __all__ = ["ServiceFactory"]


### PR DESCRIPTION
## Summary by Sourcery

Introduce a shared ServiceFactory-based helper module for CLI commands and wire audio CLI commands to use it with property-based service access and centralized result/error handling.

Enhancements:
- Add convenience properties to ServiceFactory for direct access to individual services without explicit create_* calls.
- Refactor audio-related CLI commands to use a singleton ServiceFactory and shared result-handling utilities instead of constructing repositories and services inline.

Documentation:
- Document CLI-specific service helper usage and patterns in a new helper module docstring.