### PR TITLE
0.1.7 dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bioamla"
-version = "0.1.6"
+version = "0.1.7"
 authors = [
   { name="John McMeen", email="johnmcmeen@gmail.com" },
 ]

--- a/src/bioamla/__init__.py
+++ b/src/bioamla/__init__.py
@@ -2,10 +2,10 @@
 BioAmla - Bioacoustics & Machine Learning Applications
 ======================================================
 
-Version: 0.1.6
+Version: 0.1.7
 """
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 # Re-export commonly used utilities for convenience
 from bioamla.core.utils import (


### PR DESCRIPTION
## Summary by Sourcery

Add configurable audio augmentation controls to AST training and standardize bioacoustic index computations on linear-amplitude precomputed spectrograms while bumping the package version.

New Features:
- Expose CLI options to enable/disable training-time audio augmentation and control augmentation strength, probability, and parameter ranges for AST model training.

Enhancements:
- Allow multiplying the AST training dataset via an augmentation multiplier to increase effective training data size.
- Make audio augmentation in AST training optional and bypass transforms cleanly when disabled.
- Update bioacoustic index functions to accept precomputed spectrograms in linear amplitude format and handle dB conversion internally, improving consistency and reuse of shared spectrograms.
- Clarify docstrings for bioacoustic index functions to document the expected format of precomputed spectrogram inputs.
- Reuse a single linear-amplitude spectrogram in compute_all_indices for multiple indices, consolidating spectrogram handling logic.

Build:
- Bump project version from 0.1.6 to 0.1.7 in pyproject.toml.