### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+
+- **Expanded acoustic measurements** — `datasets.compute_measurements` now spans the time,
+  amplitude, power, frequency, and entropy domains plus a summarized peak-frequency contour
+  (~24 new metrics: `zero_crossing_rate`, `peak_time`, `rms_db`/`peak_db`/`crest_factor_db`/
+  `dynamic_range`, `avg_power`/`max_power`/`energy`, `peak_frequency`, frequency
+  quartiles/percentiles (`freq_q1`/`freq_q3`/`freq_5`/`freq_95`) and `bandwidth_90`/
+  `bandwidth_iqr`, `spectral_entropy`/`temporal_entropy`, and `pfc_*` contour summaries). New
+  frequency metrics honour each annotation's `low_freq`/`high_freq` band, matching the existing
+  `centroid`/`rolloff`. Pass `metrics="all"` for the full set; `ALL_METRICS` and the unchanged
+  `DEFAULT_METRICS` are exported from `bioamla.datasets`. Uncomputable metrics are omitted, not
+  emitted as `NaN`.
+
+### Changed
+
+- **CLI dependencies are now an optional `[cli]` extra.** `click` and `rich` moved out of the
+  base install into `pip install bioamla[cli]`; the library itself never imports them. The
+  `bioamla` console command now prints an install hint instead of a raw `ModuleNotFoundError`
+  when the extra is absent. `[dev]` includes `[cli]`, so contributor installs are unchanged.
+
 ## [0.2.0] - 2026-06-12
 
 A ground-up rebuild. `bioamla` is now a flat, **domain-oriented** library with a thin CLI,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-24
+
 ### Added
 
 - **Expanded acoustic measurements** — `datasets.compute_measurements` now spans the time,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,15 @@ clustering, species catalogs, dataset tooling, and AST-based ML inference.
    `bioamla/__init__.py`); heavy third-party deps (torch, librosa, umap, hdbscan,
    sounddevice, transformers) are **imported inside the functions that use them**, never at
    module top level of an eagerly-imported module. Keep `bioamla --help` snappy.
-4. **Batteries included, but lazy.** A single `pip install bioamla` installs the full runtime
-   stack (it's all in `[project.dependencies]` — there are no runtime extras; only `[dev]`).
-   `DependencyError` is therefore reserved for genuine environment breakage (missing system
-   lib like ffmpeg, broken install), not for "optional package not installed."
+4. **Batteries included, but lazy.** A single `pip install bioamla` installs the full
+   analysis/ML runtime stack (numpy, scipy, librosa, torch, transformers, … — all in
+   `[project.dependencies]`). `DependencyError` is therefore reserved for genuine environment
+   breakage (missing system lib like ffmpeg, broken install), not for "optional package not
+   installed." The **only** runtime extra is `[cli]` (`click`, `rich`): the *library* never
+   imports them, just the `bioamla` console command, so the CLI is installed with
+   `pip install bioamla[cli]`. The console script entry point is the dependency-light shim
+   `bioamla/_cli_entry.py`, which prints an install hint (instead of a raw `ModuleNotFoundError`)
+   when run without the extra. `[dev]` pulls in `[cli]` so the test suite can exercise the CLI.
 5. **The public surface of a domain is its `__init__.py`.** Re-export the intended API there
    with an explicit `__all__`. Internal-only modules are prefixed `_` (e.g. `_models.py`,
    `_io.py`, `_metadata.py`).

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help: ## Show this help
 install: ## Create venv and install the project with dev tooling
 	$(UV) sync --extra dev
 
-dev: ## Install the full stack + dev tooling (runtime deps are all in base)
+dev: ## Install the full stack + dev tooling (dev includes the [cli] extra)
 	$(UV) sync --extra dev
 
 sync: ## Sync the environment to the lockfile (incl. dev tooling)

--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ Two conventions matter for consumers:
 - **Errors are exceptions.** Functions return plain data and raise from a single hierarchy
   rooted at `bioamla.exceptions.BioamlaError` (e.g. `AudioLoadError`, `InvalidInputError`,
   `DependencyError`). Catch the base class to handle everything.
-- **Batteries included.** A single `pip install bioamla` installs the full runtime stack —
-  audio/signal/indices/detect/viz, the PyTorch + AST ML stack, clustering, and playback. Heavy
-  imports are still **lazy**, so `import bioamla` and `bioamla --help` stay fast and don't load
-  torch until you actually call a feature that needs it.
+- **Batteries included.** A single `pip install bioamla` installs the full analysis/ML runtime
+  stack — audio/signal/indices/detect/viz, the PyTorch + AST ML stack, clustering, and playback.
+  Heavy imports are still **lazy**, so `import bioamla` and `bioamla --help` stay fast and don't
+  load torch until you actually call a feature that needs it. The command-line interface lives in
+  a thin `[cli]` extra (`pip install bioamla[cli]`) — the library never imports it.
 
 ## Install
 
@@ -48,10 +49,14 @@ Requires Python ≥ 3.10. Install into a **virtual environment** so bioamla's de
 
 ```bash
 python -m venv .venv && source .venv/bin/activate    # or: uv venv / conda create -n bioamla
-pip install bioamla                 # the full library + CLI
+pip install bioamla                 # the full analysis/ML library
 
-pip install "bioamla[dev]"          # + contributor tooling (pytest, ruff, mkdocs)
+pip install "bioamla[cli]"          # + the `bioamla` command-line interface
+pip install "bioamla[dev]"          # + contributor tooling (pytest, ruff, mkdocs; includes [cli])
 ```
+
+The `bioamla` console command needs the `[cli]` extra; on a library-only install it prints an
+install hint pointing you to `pip install bioamla[cli]`.
 
 ### System dependencies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,6 @@ classifiers = [
 ]
 
 dependencies = [
-  "click",
-  "rich",
   "tomli>=2.0; python_version < '3.11'",
   "python-dotenv>=1.0",
   "numpy",
@@ -62,10 +60,18 @@ dependencies = [
 ]
 
 [project.scripts]
-bioamla = "bioamla.cli.cli:main"
+bioamla = "bioamla._cli_entry:main"
 
 [project.optional-dependencies]
+# The command-line interface. The library itself (`import bioamla`) does not need
+# these — only the `bioamla` console command does. Install with
+# `pip install bioamla[cli]` to get the CLI.
+cli = [
+  "click",
+  "rich",
+]
 dev = [
+  "bioamla[cli]",  # the test suite exercises the CLI, so dev pulls in the cli extra
   "pytest>=7.0",
   "pytest-cov",
   "pytest-mock",

--- a/src/bioamla/_cli_entry.py
+++ b/src/bioamla/_cli_entry.py
@@ -1,0 +1,41 @@
+"""Console-script entry point for the ``bioamla`` command.
+
+The CLI dependencies (``click``, ``rich``) live in the optional ``[cli]`` extra,
+not the base install (see ``pyproject.toml``). This thin shim is the target of
+the ``bioamla`` console script: it imports nothing CLI-specific at module top,
+so that on a library-only install (``pip install bioamla``) running ``bioamla``
+prints a friendly "install the extra" message instead of a raw
+``ModuleNotFoundError`` traceback.
+
+Keep this module dependency-light: importing it must not pull in ``click`` /
+``rich``, otherwise the guard below never gets a chance to run.
+"""
+
+from __future__ import annotations
+
+import sys
+
+# Names of the CLI-only dependencies. A missing one of these means the CLI extra
+# was not installed; anything else is a genuine import error we let propagate.
+_CLI_DEPS = frozenset({"click", "rich"})
+
+_INSTALL_HINT = (
+    "The bioamla CLI requires extra dependencies that are not installed.\n"
+    "Install them with:  pip install 'bioamla[cli]'\n"
+)
+
+
+def main() -> None:
+    """Run the bioamla CLI, or explain how to install it if the extra is absent."""
+    try:
+        from bioamla.cli.cli import main as _cli_main
+    except ModuleNotFoundError as exc:
+        if exc.name in _CLI_DEPS:
+            sys.stderr.write(_INSTALL_HINT)
+            raise SystemExit(1) from exc
+        raise
+    _cli_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bioamla/datasets/__init__.py
+++ b/src/bioamla/datasets/__init__.py
@@ -74,7 +74,11 @@ from bioamla.datasets.manifest import (
     save_dataset_manifest,
     write_dataset_card,
 )
-from bioamla.datasets.measurements import compute_measurements
+from bioamla.datasets.measurements import (
+    ALL_METRICS,
+    DEFAULT_METRICS,
+    compute_measurements,
+)
 from bioamla.datasets.merge import find_species_name, merge_datasets
 from bioamla.datasets.partition import partition_dataset
 from bioamla.datasets.stats import get_dataset_stats
@@ -120,6 +124,8 @@ __all__ = [
     "extract_audio_clips",
     "extract_labeled_dataset",
     "compute_measurements",
+    "DEFAULT_METRICS",
+    "ALL_METRICS",
     # Dataset operations
     "merge_datasets",
     "find_species_name",

--- a/src/bioamla/datasets/measurements.py
+++ b/src/bioamla/datasets/measurements.py
@@ -70,6 +70,12 @@ ALL_METRICS = [
     *CONTOUR_METRICS,
 ]
 
+# Pre-built membership sets, so the per-region ``_measure_*`` helpers test
+# ``requested & <group>`` without re-allocating a set on every call.
+_ALL_METRICS = frozenset(ALL_METRICS)
+_POWER_METRICS = frozenset(POWER_METRICS)
+_ENTROPY_METRICS = frozenset(ENTROPY_METRICS)
+_CONTOUR_METRICS = frozenset(CONTOUR_METRICS)
 # Frequency metrics derived from the (band-masked) Welch PSD.
 _PSD_METRICS = frozenset(FREQUENCY_METRICS) - {"bandwidth"}
 _AMPLITUDE_DB_METRICS = frozenset({"rms_db", "peak_db", "crest_factor_db", "dynamic_range"})
@@ -151,7 +157,13 @@ def compute_measurements(
 
 
 def _resolve_metrics(metrics: list[str] | str | None) -> set[str]:
-    """Normalize the ``metrics`` argument into a set of metric names."""
+    """Normalize and validate the ``metrics`` argument into a set of metric names.
+
+    Raises:
+        AnnotationError: If ``metrics`` is a string other than ``"all"``, or a list
+            containing names that aren't in :data:`ALL_METRICS` (so typos fail fast
+            rather than being silently dropped).
+    """
     if metrics is None:
         return set(DEFAULT_METRICS)
     if isinstance(metrics, str):
@@ -160,7 +172,15 @@ def _resolve_metrics(metrics: list[str] | str | None) -> set[str]:
         raise AnnotationError(
             f"metrics must be a list of names or the string 'all', got {metrics!r}"
         )
-    return set(metrics)
+
+    resolved = set(metrics)
+    unknown = resolved - _ALL_METRICS
+    if unknown:
+        raise AnnotationError(
+            f"Unknown metric name(s): {sorted(unknown)}. "
+            f"Choose from {ALL_METRICS} or pass metrics='all'."
+        )
+    return resolved
 
 
 def _measure_time(
@@ -215,7 +235,7 @@ def _measure_amplitude(out: dict[str, float], req: set[str], clip: np.ndarray, n
 
 
 def _measure_power(out: dict[str, float], req: set[str], clip: np.ndarray, n: int) -> None:
-    if n == 0 or not (req & set(POWER_METRICS)):
+    if n == 0 or not (req & _POWER_METRICS):
         return
     squared = clip**2
     if "avg_power" in req:
@@ -286,7 +306,7 @@ def _measure_frequency(
 def _measure_entropy(
     out: dict[str, float], req: set[str], clip: np.ndarray, n: int, sample_rate: int
 ) -> None:
-    if n == 0 or not (req & set(ENTROPY_METRICS)):
+    if n == 0 or not (req & _ENTROPY_METRICS):
         return
     from bioamla.indices import spectral_entropy, temporal_entropy
 
@@ -304,7 +324,7 @@ def _measure_contour(
     n: int,
     sample_rate: int,
 ) -> None:
-    if n == 0 or not (req & set(CONTOUR_METRICS)):
+    if n == 0 or not (req & _CONTOUR_METRICS):
         return
 
     contour = _peak_freq_contour(clip, sample_rate, annotation.low_freq, annotation.high_freq)

--- a/src/bioamla/datasets/measurements.py
+++ b/src/bioamla/datasets/measurements.py
@@ -1,44 +1,122 @@
-"""Compute acoustic measurements for an annotated audio region."""
+"""Compute acoustic measurements for an annotated audio region.
+
+Measurements span five domains — **time**, **amplitude**, **power**,
+**frequency**, and **entropy** — plus a summarized **peak-frequency contour**.
+Each metric is a single scalar so the result is a flat ``dict[str, float]`` that
+merges cleanly into a measurements CSV/Parquet table (one column per metric).
+
+Frequency-domain metrics are computed from a single Welch PSD that is restricted
+to the annotation's ``low_freq``/``high_freq`` box when both bounds are set
+(matching ``centroid``/``rolloff`` behaviour); the per-frame peak-frequency
+contour honours the same band. Amplitude (dB) and entropy metrics reuse the
+domain primitives in :mod:`bioamla.audio` and :mod:`bioamla.indices`.
+
+Metrics that cannot be computed for a given region (e.g. a frequency metric when
+the PSD is empty, or the contour for a clip too short to frame) are **omitted**
+from the result rather than emitted as ``NaN``.
+"""
 
 from __future__ import annotations
 
 import logging
 from pathlib import Path
 
+import numpy as np
+
 from bioamla.datasets.annotations import Annotation
 from bioamla.exceptions import AnnotationError, NotFoundError
 
 logger = logging.getLogger(__name__)
 
+# Backward-compatible default set — kept byte-identical: existing callers and
+# tests rely on exactly these five metrics being returned when ``metrics`` is None.
 DEFAULT_METRICS = ["duration", "bandwidth", "rms", "peak", "centroid"]
+
+# Full metric vocabulary, grouped by domain. ``metrics="all"`` expands to ALL_METRICS.
+TIME_METRICS = ["duration", "zero_crossing_rate", "peak_time"]
+AMPLITUDE_METRICS = [
+    "rms",
+    "peak",
+    "crest_factor",
+    "rms_db",
+    "peak_db",
+    "crest_factor_db",
+    "dynamic_range",
+]
+POWER_METRICS = ["avg_power", "max_power", "energy"]
+FREQUENCY_METRICS = [
+    "bandwidth",
+    "centroid",
+    "bandwidth_spectral",
+    "rolloff",
+    "peak_frequency",
+    "freq_q1",
+    "freq_q3",
+    "freq_5",
+    "freq_95",
+    "bandwidth_90",
+    "bandwidth_iqr",
+]
+ENTROPY_METRICS = ["spectral_entropy", "temporal_entropy"]
+CONTOUR_METRICS = ["pfc_min", "pfc_max", "pfc_mean", "pfc_start", "pfc_end", "pfc_slope"]
+
+# Every supported metric, in a stable, domain-grouped order.
+ALL_METRICS = [
+    *TIME_METRICS,
+    *AMPLITUDE_METRICS,
+    *POWER_METRICS,
+    *FREQUENCY_METRICS,
+    *ENTROPY_METRICS,
+    *CONTOUR_METRICS,
+]
+
+# Frequency metrics derived from the (band-masked) Welch PSD.
+_PSD_METRICS = frozenset(FREQUENCY_METRICS) - {"bandwidth"}
+_AMPLITUDE_DB_METRICS = frozenset({"rms_db", "peak_db", "crest_factor_db", "dynamic_range"})
 
 
 def compute_measurements(
     annotation: Annotation,
     audio_path: str,
-    metrics: list[str] | None = None,
+    metrics: list[str] | str | None = None,
 ) -> dict[str, float]:
     """Compute acoustic measurements for one annotation region.
 
     Args:
         annotation: The annotation to measure.
         audio_path: Path to the source audio file.
-        metrics: Metrics to compute. If None, uses :data:`DEFAULT_METRICS`.
-            Supported: duration, bandwidth, rms, peak, crest_factor, centroid,
-            bandwidth_spectral, rolloff.
+        metrics: Metrics to compute. ``None`` uses :data:`DEFAULT_METRICS`; the
+            string ``"all"`` expands to :data:`ALL_METRICS`; otherwise pass a list
+            of metric names. Supported names, grouped by domain:
+
+            * **time**: ``duration``, ``zero_crossing_rate`` (crossings per
+              sample, 0–1), ``peak_time`` (s from region start)
+            * **amplitude**: ``rms``, ``peak`` (linear), ``crest_factor``
+              (linear peak/rms), ``rms_db``, ``peak_db`` (dBFS),
+              ``crest_factor_db`` (dB), ``dynamic_range`` (dB)
+            * **power**: ``avg_power``, ``max_power``, ``energy`` (Σ x²)
+            * **frequency** (band-limited Welch PSD): ``bandwidth`` (annotation
+              box width), ``centroid``, ``bandwidth_spectral``, ``rolloff``
+              (85%), ``peak_frequency``, ``freq_q1``/``freq_q3`` (25/75%),
+              ``freq_5``/``freq_95`` (5/95%), ``bandwidth_90`` (95−5%),
+              ``bandwidth_iqr`` (75−25%)
+            * **entropy**: ``spectral_entropy``, ``temporal_entropy``
+            * **peak-frequency contour**: ``pfc_min``, ``pfc_max``, ``pfc_mean``,
+              ``pfc_start``, ``pfc_end``, ``pfc_slope`` (Hz/s)
 
     Returns:
-        Dict mapping metric name to value.
+        Dict mapping metric name to value. Metrics that cannot be computed for
+        the region are omitted.
 
     Raises:
         NotFoundError: If the audio file doesn't exist.
-        AnnotationError: If the audio cannot be loaded or measured.
+        AnnotationError: If ``metrics`` is malformed, or the audio cannot be
+            loaded or measured.
     """
     if not Path(audio_path).exists():
         raise NotFoundError(f"Audio file not found: {audio_path}")
 
-    import numpy as np
-    from scipy import signal as scipy_signal
+    requested = _resolve_metrics(metrics)
 
     from bioamla.audio import load_audio
 
@@ -55,54 +133,247 @@ def compute_measurements(
 
     channel_idx = min(annotation.channel - 1, audio_data.shape[1] - 1)
     clip = audio_data[start_sample:end_sample, channel_idx]
-
-    if metrics is None:
-        metrics = list(DEFAULT_METRICS)
+    n = len(clip)
 
     measurements: dict[str, float] = {}
 
     try:
-        if "duration" in metrics:
-            measurements["duration"] = annotation.duration
-
-        if "bandwidth" in metrics and annotation.bandwidth is not None:
-            measurements["bandwidth"] = annotation.bandwidth
-
-        if "rms" in metrics:
-            measurements["rms"] = float(np.sqrt(np.mean(clip**2)))
-
-        if "peak" in metrics:
-            measurements["peak"] = float(np.max(np.abs(clip)))
-
-        if "crest_factor" in metrics:
-            rms = np.sqrt(np.mean(clip**2))
-            peak = np.max(np.abs(clip))
-            measurements["crest_factor"] = float(peak / rms) if rms > 0 else 0.0
-
-        if any(m in metrics for m in ["centroid", "bandwidth_spectral", "rolloff"]):
-            n_fft = min(2048, len(clip))
-            freqs, psd = scipy_signal.welch(clip, sample_rate, nperseg=n_fft)
-
-            if annotation.low_freq is not None and annotation.high_freq is not None:
-                mask = (freqs >= annotation.low_freq) & (freqs <= annotation.high_freq)
-                freqs = freqs[mask]
-                psd = psd[mask]
-
-            if len(psd) > 0 and np.sum(psd) > 0:
-                if "centroid" in metrics:
-                    measurements["centroid"] = float(np.sum(freqs * psd) / np.sum(psd))
-
-                if "bandwidth_spectral" in metrics:
-                    centroid = np.sum(freqs * psd) / np.sum(psd)
-                    measurements["bandwidth_spectral"] = float(
-                        np.sqrt(np.sum((freqs - centroid) ** 2 * psd) / np.sum(psd))
-                    )
-
-                if "rolloff" in metrics:
-                    cumsum = np.cumsum(psd)
-                    rolloff_idx = np.searchsorted(cumsum, 0.85 * cumsum[-1])
-                    measurements["rolloff"] = float(freqs[min(rolloff_idx, len(freqs) - 1)])
+        _measure_time(measurements, requested, annotation, clip, n, sample_rate)
+        _measure_amplitude(measurements, requested, clip, n)
+        _measure_power(measurements, requested, clip, n)
+        _measure_frequency(measurements, requested, annotation, clip, n, sample_rate)
+        _measure_entropy(measurements, requested, clip, n, sample_rate)
+        _measure_contour(measurements, requested, annotation, clip, n, sample_rate)
     except Exception as e:
         raise AnnotationError(f"Failed to compute measurements: {e}") from e
 
     return measurements
+
+
+def _resolve_metrics(metrics: list[str] | str | None) -> set[str]:
+    """Normalize the ``metrics`` argument into a set of metric names."""
+    if metrics is None:
+        return set(DEFAULT_METRICS)
+    if isinstance(metrics, str):
+        if metrics == "all":
+            return set(ALL_METRICS)
+        raise AnnotationError(
+            f"metrics must be a list of names or the string 'all', got {metrics!r}"
+        )
+    return set(metrics)
+
+
+def _measure_time(
+    out: dict[str, float],
+    req: set[str],
+    annotation: Annotation,
+    clip: np.ndarray,
+    n: int,
+    sample_rate: int,
+) -> None:
+    if "duration" in req:
+        out["duration"] = annotation.duration
+    if n == 0:
+        return
+    if "zero_crossing_rate" in req:
+        if n > 1:
+            crossings = int(np.count_nonzero(np.diff(np.signbit(clip))))
+            out["zero_crossing_rate"] = float(crossings / (n - 1))
+        else:
+            out["zero_crossing_rate"] = 0.0
+    if "peak_time" in req:
+        out["peak_time"] = float(int(np.argmax(np.abs(clip))) / sample_rate)
+
+
+def _measure_amplitude(out: dict[str, float], req: set[str], clip: np.ndarray, n: int) -> None:
+    if n == 0:
+        return
+    if "rms" in req:
+        out["rms"] = float(np.sqrt(np.mean(clip**2)))
+    if "peak" in req:
+        out["peak"] = float(np.max(np.abs(clip)))
+    if "crest_factor" in req:
+        rms = np.sqrt(np.mean(clip**2))
+        peak = np.max(np.abs(clip))
+        out["crest_factor"] = float(peak / rms) if rms > 0 else 0.0
+    # dB metrics are undefined for digital silence (dBFS -> -inf, dynamic_range
+    # -> NaN), so omit them rather than emit non-finite values.
+    if req & _AMPLITUDE_DB_METRICS and np.max(np.abs(clip)) > 0:
+        from bioamla.audio import get_amplitude_stats
+
+        # NB: AmplitudeStats.crest_factor is the dB form (peak_db − rms_db); the
+        # linear ``crest_factor`` above is a distinct metric, kept for compat.
+        stats = get_amplitude_stats(clip)
+        if "rms_db" in req:
+            out["rms_db"] = stats.rms_db
+        if "peak_db" in req:
+            out["peak_db"] = stats.peak_db
+        if "crest_factor_db" in req:
+            out["crest_factor_db"] = stats.crest_factor
+        if "dynamic_range" in req:
+            out["dynamic_range"] = stats.dynamic_range
+
+
+def _measure_power(out: dict[str, float], req: set[str], clip: np.ndarray, n: int) -> None:
+    if n == 0 or not (req & set(POWER_METRICS)):
+        return
+    squared = clip**2
+    if "avg_power" in req:
+        out["avg_power"] = float(np.mean(squared))
+    if "max_power" in req:
+        out["max_power"] = float(np.max(squared))
+    if "energy" in req:
+        out["energy"] = float(np.sum(squared))
+
+
+def _measure_frequency(
+    out: dict[str, float],
+    req: set[str],
+    annotation: Annotation,
+    clip: np.ndarray,
+    n: int,
+    sample_rate: int,
+) -> None:
+    if "bandwidth" in req and annotation.bandwidth is not None:
+        out["bandwidth"] = annotation.bandwidth
+
+    if n == 0 or not (req & _PSD_METRICS):
+        return
+
+    from scipy import signal as scipy_signal
+
+    n_fft = min(2048, n)
+    freqs, psd = scipy_signal.welch(clip, sample_rate, nperseg=n_fft)
+
+    if annotation.low_freq is not None and annotation.high_freq is not None:
+        mask = (freqs >= annotation.low_freq) & (freqs <= annotation.high_freq)
+        freqs = freqs[mask]
+        psd = psd[mask]
+
+    if len(psd) == 0 or np.sum(psd) <= 0:
+        return
+
+    total = float(np.sum(psd))
+    cumsum = np.cumsum(psd)
+
+    if "peak_frequency" in req:
+        out["peak_frequency"] = float(freqs[int(np.argmax(psd))])
+    if "centroid" in req:
+        out["centroid"] = float(np.sum(freqs * psd) / total)
+    if "bandwidth_spectral" in req:
+        centroid = np.sum(freqs * psd) / total
+        out["bandwidth_spectral"] = float(np.sqrt(np.sum((freqs - centroid) ** 2 * psd) / total))
+    if "rolloff" in req:
+        out["rolloff"] = _percentile_freq(freqs, cumsum, 0.85)
+    if "freq_q1" in req:
+        out["freq_q1"] = _percentile_freq(freqs, cumsum, 0.25)
+    if "freq_q3" in req:
+        out["freq_q3"] = _percentile_freq(freqs, cumsum, 0.75)
+    if "freq_5" in req:
+        out["freq_5"] = _percentile_freq(freqs, cumsum, 0.05)
+    if "freq_95" in req:
+        out["freq_95"] = _percentile_freq(freqs, cumsum, 0.95)
+    if "bandwidth_90" in req:
+        out["bandwidth_90"] = _percentile_freq(freqs, cumsum, 0.95) - _percentile_freq(
+            freqs, cumsum, 0.05
+        )
+    if "bandwidth_iqr" in req:
+        out["bandwidth_iqr"] = _percentile_freq(freqs, cumsum, 0.75) - _percentile_freq(
+            freqs, cumsum, 0.25
+        )
+
+
+def _measure_entropy(
+    out: dict[str, float], req: set[str], clip: np.ndarray, n: int, sample_rate: int
+) -> None:
+    if n == 0 or not (req & set(ENTROPY_METRICS)):
+        return
+    from bioamla.indices import spectral_entropy, temporal_entropy
+
+    if "spectral_entropy" in req:
+        out["spectral_entropy"] = spectral_entropy(clip, sample_rate)
+    if "temporal_entropy" in req:
+        out["temporal_entropy"] = temporal_entropy(clip, sample_rate)
+
+
+def _measure_contour(
+    out: dict[str, float],
+    req: set[str],
+    annotation: Annotation,
+    clip: np.ndarray,
+    n: int,
+    sample_rate: int,
+) -> None:
+    if n == 0 or not (req & set(CONTOUR_METRICS)):
+        return
+
+    contour = _peak_freq_contour(clip, sample_rate, annotation.low_freq, annotation.high_freq)
+    if contour is None:
+        return
+    times, peak_freqs = contour
+
+    if "pfc_min" in req:
+        out["pfc_min"] = float(np.min(peak_freqs))
+    if "pfc_max" in req:
+        out["pfc_max"] = float(np.max(peak_freqs))
+    if "pfc_mean" in req:
+        out["pfc_mean"] = float(np.mean(peak_freqs))
+    if "pfc_start" in req:
+        out["pfc_start"] = float(peak_freqs[0])
+    if "pfc_end" in req:
+        out["pfc_end"] = float(peak_freqs[-1])
+    if "pfc_slope" in req:
+        if len(peak_freqs) >= 2 and (times[-1] - times[0]) > 0:
+            out["pfc_slope"] = float(np.polyfit(times, peak_freqs, 1)[0])
+        else:
+            out["pfc_slope"] = 0.0
+
+
+def _percentile_freq(freqs: np.ndarray, cumsum: np.ndarray, fraction: float) -> float:
+    """Frequency below which ``fraction`` of the cumulative PSD energy lies.
+
+    Keyed off ``cumsum[-1]`` (the sequential running total) so ``rolloff`` stays
+    bit-identical to its pre-expansion definition.
+    """
+    idx = int(np.searchsorted(cumsum, fraction * cumsum[-1]))
+    return float(freqs[min(idx, len(freqs) - 1)])
+
+
+def _peak_freq_contour(
+    clip: np.ndarray,
+    sample_rate: int,
+    low_freq: float | None,
+    high_freq: float | None,
+) -> tuple[np.ndarray, np.ndarray] | None:
+    """Per-frame peak-frequency track of the clip (band-limited when bounds set).
+
+    Returns ``(frame_times, peak_freqs)`` over frames with non-zero energy, or
+    ``None`` if the clip is too short to frame or has no signal.
+    """
+    n = len(clip)
+    if n < 32:
+        return None
+
+    from scipy import signal as scipy_signal
+
+    nperseg = min(256, n)
+    freqs, times, zxx = scipy_signal.stft(
+        clip, fs=sample_rate, nperseg=nperseg, noverlap=nperseg // 2
+    )
+    mag = np.abs(zxx)
+
+    if low_freq is not None and high_freq is not None:
+        mask = (freqs >= low_freq) & (freqs <= high_freq)
+        if np.any(mask):
+            freqs = freqs[mask]
+            mag = mag[mask, :]
+
+    # Drop silent frames so the contour reflects the signal, not the noise floor.
+    keep = mag.max(axis=0) > 0
+    if not np.any(keep):
+        return None
+
+    mag = mag[:, keep]
+    frame_times = times[keep]
+    peak_freqs = freqs[np.argmax(mag, axis=0)]
+    return frame_times, peak_freqs

--- a/tests/datasets/test_measurements.py
+++ b/tests/datasets/test_measurements.py
@@ -7,7 +7,11 @@ import pytest
 import scipy.io.wavfile as wav
 
 from bioamla.datasets.annotations import Annotation
-from bioamla.datasets.measurements import DEFAULT_METRICS, compute_measurements
+from bioamla.datasets.measurements import (
+    ALL_METRICS,
+    DEFAULT_METRICS,
+    compute_measurements,
+)
 from bioamla.exceptions import AnnotationError, NotFoundError
 
 
@@ -18,6 +22,33 @@ def chirp_audio_path(tmp_path) -> str:
     t = np.linspace(0, 2.0, int(sample_rate * 2.0), dtype=np.float32)
     samples = (0.5 * np.sin(2 * np.pi * 1000.0 * t) * 32767).astype(np.int16)
     path = tmp_path / "chirp.wav"
+    wav.write(str(path), sample_rate, samples)
+    return str(path)
+
+
+@pytest.fixture
+def sweep_audio_path(tmp_path) -> str:
+    """A 2-second 16 kHz linear frequency sweep (500 -> 3000 Hz) for contour tests."""
+    from scipy.signal import chirp
+
+    sample_rate = 16000
+    t = np.linspace(0, 2.0, int(sample_rate * 2.0), dtype=np.float32)
+    samples = (0.5 * chirp(t, f0=500.0, f1=3000.0, t1=2.0, method="linear") * 32767).astype(
+        np.int16
+    )
+    path = tmp_path / "sweep.wav"
+    wav.write(str(path), sample_rate, samples)
+    return str(path)
+
+
+@pytest.fixture
+def two_tone_audio_path(tmp_path) -> str:
+    """A 16 kHz file with a weak 1 kHz tone and a strong 6 kHz tone."""
+    sample_rate = 16000
+    t = np.linspace(0, 2.0, int(sample_rate * 2.0), dtype=np.float32)
+    signal = 0.2 * np.sin(2 * np.pi * 1000.0 * t) + 0.6 * np.sin(2 * np.pi * 6000.0 * t)
+    samples = (signal * 32767).astype(np.int16)
+    path = tmp_path / "two_tone.wav"
     wav.write(str(path), sample_rate, samples)
     return str(path)
 
@@ -83,3 +114,120 @@ class TestComputeMeasurements:
         ann = _ann(channel=5)
         m = compute_measurements(ann, chirp_audio_path, metrics=["rms"])
         assert "rms" in m
+
+
+class TestExpandedMetrics:
+    """Coverage for the expanded time/amplitude/power/frequency/entropy/contour metrics."""
+
+    def test_metrics_all_returns_full_set(self, chirp_audio_path: str) -> None:
+        # A clean tone with freq bounds -> nothing is uncomputable, so "all" is complete.
+        m = compute_measurements(_ann(), chirp_audio_path, metrics="all")
+        assert set(m) == set(ALL_METRICS)
+
+    def test_invalid_metrics_string_raises(self, chirp_audio_path: str) -> None:
+        with pytest.raises(AnnotationError, match="metrics must be a list"):
+            compute_measurements(_ann(), chirp_audio_path, metrics="rms")  # not a list, not "all"
+
+    def test_time_domain(self, chirp_audio_path: str) -> None:
+        m = compute_measurements(
+            _ann(), chirp_audio_path, metrics=["zero_crossing_rate", "peak_time"]
+        )
+        # 1 kHz tone at 16 kHz -> 2000 zero crossings/s -> 0.125 crossings per sample.
+        assert m["zero_crossing_rate"] == pytest.approx(0.125, abs=0.01)
+        # Peak of a sine occurs within its first cycle (< 1 ms in).
+        assert 0.0 <= m["peak_time"] < 0.01
+
+    def test_amplitude_db_metrics(self, chirp_audio_path: str) -> None:
+        metrics = ["peak_db", "rms_db", "crest_factor_db", "dynamic_range"]
+        m = compute_measurements(_ann(), chirp_audio_path, metrics=metrics)
+        assert set(m) == set(metrics)
+        assert m["peak_db"] < 0.0  # below full scale
+        assert m["rms_db"] < m["peak_db"]
+        # Crest factor of a sine is ~3.01 dB; dynamic_range mirrors it here.
+        assert m["crest_factor_db"] == pytest.approx(3.01, abs=0.3)
+        assert m["dynamic_range"] == pytest.approx(m["crest_factor_db"], abs=1e-6)
+
+    def test_power_metrics(self, chirp_audio_path: str) -> None:
+        m = compute_measurements(
+            _ann(), chirp_audio_path, metrics=["avg_power", "max_power", "energy", "rms", "peak"]
+        )
+        # avg_power == rms**2, max_power == peak**2.
+        assert m["avg_power"] == pytest.approx(m["rms"] ** 2, rel=1e-5)
+        assert m["max_power"] == pytest.approx(m["peak"] ** 2, rel=1e-5)
+        assert m["energy"] > 0.0
+
+    def test_frequency_percentiles_band_limited(self, chirp_audio_path: str) -> None:
+        metrics = [
+            "peak_frequency",
+            "freq_q1",
+            "freq_q3",
+            "freq_5",
+            "freq_95",
+            "bandwidth_90",
+            "bandwidth_iqr",
+        ]
+        m = compute_measurements(_ann(), chirp_audio_path, metrics=metrics)
+        assert set(m) == set(metrics)
+        # Energy of a 1 kHz tone sits at ~1 kHz; percentiles bracket it tightly.
+        assert m["peak_frequency"] == pytest.approx(1000.0, abs=30.0)
+        assert m["freq_5"] <= 1000.0 <= m["freq_95"]
+        assert m["bandwidth_90"] >= 0.0
+        assert m["bandwidth_iqr"] >= 0.0
+
+    def test_new_freq_metrics_respect_annotation_band(self, two_tone_audio_path: str) -> None:
+        # Strong 6 kHz tone is outside a 200-4000 Hz box -> peak_frequency tracks the
+        # in-band 1 kHz tone, not the louder out-of-band one.
+        ann = _ann(low_freq=200.0, high_freq=4000.0)
+        m = compute_measurements(ann, two_tone_audio_path, metrics=["peak_frequency"])
+        assert m["peak_frequency"] == pytest.approx(1000.0, abs=50.0)
+
+    def test_new_freq_metrics_full_band_when_no_bounds(self, two_tone_audio_path: str) -> None:
+        # Without freq bounds the louder 6 kHz tone wins.
+        ann = _ann(low_freq=None, high_freq=None)
+        m = compute_measurements(ann, two_tone_audio_path, metrics=["peak_frequency"])
+        assert m["peak_frequency"] == pytest.approx(6000.0, abs=50.0)
+
+    def test_entropy_metrics(self, chirp_audio_path: str) -> None:
+        m = compute_measurements(
+            _ann(), chirp_audio_path, metrics=["spectral_entropy", "temporal_entropy"]
+        )
+        assert m["spectral_entropy"] >= 0.0
+        assert m["temporal_entropy"] >= 0.0
+
+    def test_contour_on_constant_tone(self, chirp_audio_path: str) -> None:
+        metrics = ["pfc_min", "pfc_max", "pfc_mean", "pfc_start", "pfc_end", "pfc_slope"]
+        m = compute_measurements(_ann(), chirp_audio_path, metrics=metrics)
+        assert set(m) == set(metrics)
+        # Constant 1 kHz tone -> flat contour near 1 kHz, ~zero slope.
+        assert m["pfc_mean"] == pytest.approx(1000.0, abs=70.0)
+        assert m["pfc_slope"] == pytest.approx(0.0, abs=50.0)
+
+    def test_contour_tracks_rising_sweep(self, sweep_audio_path: str) -> None:
+        # Whole 500 -> 3000 Hz sweep; band 200-4000 covers it.
+        ann = _ann(start_time=0.0, end_time=2.0)
+        metrics = ["pfc_start", "pfc_end", "pfc_slope"]
+        m = compute_measurements(ann, sweep_audio_path, metrics=metrics)
+        assert m["pfc_end"] > m["pfc_start"]  # rising contour
+        assert m["pfc_slope"] > 0.0
+
+    def test_db_metrics_omitted_for_silence(self, tmp_path) -> None:
+        # dBFS of digital silence is -inf and dynamic_range is NaN -> omit, don't emit.
+        sample_rate = 16000
+        samples = np.zeros(sample_rate, dtype=np.int16)
+        path = tmp_path / "silent.wav"
+        wav.write(str(path), sample_rate, samples)
+        ann = _ann(start_time=0.1, end_time=0.5)
+        m = compute_measurements(
+            ann, str(path), metrics=["rms_db", "peak_db", "dynamic_range", "avg_power"]
+        )
+        assert "rms_db" not in m
+        assert "peak_db" not in m
+        assert "dynamic_range" not in m
+        assert m["avg_power"] == 0.0  # power metrics are still well-defined (zero)
+
+    def test_contour_omitted_for_short_clip(self, chirp_audio_path: str) -> None:
+        # A sub-millisecond region is too short to frame -> contour metrics omitted.
+        ann = _ann(start_time=0.2, end_time=0.2005)
+        m = compute_measurements(ann, chirp_audio_path, metrics=["pfc_mean", "rms"])
+        assert "pfc_mean" not in m
+        assert "rms" in m  # other metrics still computed

--- a/tests/datasets/test_measurements.py
+++ b/tests/datasets/test_measurements.py
@@ -128,6 +128,11 @@ class TestExpandedMetrics:
         with pytest.raises(AnnotationError, match="metrics must be a list"):
             compute_measurements(_ann(), chirp_audio_path, metrics="rms")  # not a list, not "all"
 
+    def test_unknown_metric_name_raises(self, chirp_audio_path: str) -> None:
+        # Typos fail fast instead of being silently dropped.
+        with pytest.raises(AnnotationError, match="Unknown metric name"):
+            compute_measurements(_ann(), chirp_audio_path, metrics=["rms", "centorid"])
+
     def test_time_domain(self, chirp_audio_path: str) -> None:
         m = compute_measurements(
             _ann(), chirp_audio_path, metrics=["zero_crossing_rate", "peak_time"]

--- a/uv.lock
+++ b/uv.lock
@@ -394,7 +394,6 @@ name = "bioamla"
 source = { editable = "." }
 dependencies = [
     { name = "audiomentations" },
-    { name = "click" },
     { name = "datasets", extra = ["audio"] },
     { name = "evaluate" },
     { name = "hdbscan" },
@@ -411,7 +410,6 @@ dependencies = [
     { name = "pyinaturalist" },
     { name = "python-dotenv" },
     { name = "requests" },
-    { name = "rich" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -428,7 +426,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cli = [
+    { name = "click" },
+    { name = "rich" },
+]
 dev = [
+    { name = "click" },
     { name = "mkdocs" },
     { name = "mkdocs-click" },
     { name = "mkdocs-material" },
@@ -438,13 +441,15 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "rich" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "audiomentations" },
-    { name = "click" },
+    { name = "click", marker = "extra == 'cli'" },
+    { name = "click", marker = "extra == 'dev'" },
     { name = "datasets", extras = ["audio"] },
     { name = "evaluate" },
     { name = "hdbscan", specifier = ">=0.8.0" },
@@ -469,7 +474,8 @@ requires-dist = [
     { name = "pytest-mock", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = ">=1.0" },
     { name = "requests", specifier = ">=2.28.0" },
-    { name = "rich" },
+    { name = "rich", marker = "extra == 'cli'" },
+    { name = "rich", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scikit-learn", specifier = ">=1.0.0" },
     { name = "scipy" },
@@ -483,7 +489,7 @@ requires-dist = [
     { name = "transformers", extras = ["torch"], specifier = ">=5.10.2" },
     { name = "umap-learn", specifier = ">=0.5.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["cli", "dev"]
 
 [[package]]
 name = "blinker"


### PR DESCRIPTION
## Summary

What does this PR change, and why?

## Related issues

Closes #54 
Closes #55 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [x] Docs
- [ ] Other:

## Checklist

- [ x] `make check` passes (lint + format-check + tests)
- [ x] Added/updated tests for the change
- [ x] Updated docs / `CHANGELOG.md` if user-facing
- [x] Follows project conventions (errors → `BioamlaError`, domain layout, lazy
      heavy imports, thin CLI) — see [CONTRIBUTING.md](../CONTRIBUTING.md)

## Notes for reviewers

NA

## Summary by Sourcery

Expand acoustic measurement capabilities and decouple the CLI into an optional extra while updating docs and packaging to match.

New Features:
- Add a rich set of time, amplitude, power, frequency, entropy, and peak-frequency contour metrics to dataset measurements, with support for metrics="all" and exported DEFAULT_METRICS/ALL_METRICS.
- Introduce a lightweight CLI entry shim that prints an install hint when the optional [cli] dependencies are missing, and move the CLI into an installable extras group.

Enhancements:
- Refactor measurement computation into domain-specific helpers with stricter metric validation and omission of uncomputable metrics instead of returning NaN values.

Build:
- Move CLI dependencies (click, rich) from core requirements into a [cli] optional extra, wire the bioamla console script to the new shim entry point, and update dev extras and Makefile help text accordingly.

Documentation:
- Document the expanded measurement API and new metrics in the changelog, and clarify README/CLAUDE guidance around the optional [cli] extra and installation variants.

Tests:
- Add comprehensive tests covering the expanded measurement metrics, band-limited behavior, contour tracking, and edge cases such as silence and short clips.